### PR TITLE
Added Currency Converter via http://fixer.io/

### DIFF
--- a/NiceHashMiner/Config.cs
+++ b/NiceHashMiner/Config.cs
@@ -46,6 +46,7 @@ namespace NiceHashMiner
 #pragma warning disable 649
         public Version ConfigFileVersion;
         public int Language;
+        public string DisplayCurrency;
         public bool DebugConsole;
         public string BitcoinAddress;
         public string WorkerName;
@@ -181,6 +182,7 @@ namespace NiceHashMiner
             ConfigData.SwitchMinSecondsDynamic = 30;
             ConfigData.SwitchMinSecondsAMD = 90;
             ConfigData.MinIdleSeconds = 60;
+            ConfigData.DisplayCurrency = "USD";
         }
 
         public static void Commit()

--- a/NiceHashMiner/CurrencyConverter.cs
+++ b/NiceHashMiner/CurrencyConverter.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Net;
 
 namespace NiceHashMiner.CurrencyConverter
@@ -32,73 +33,14 @@ namespace NiceHashMiner.CurrencyConverter
             }
 
             Helpers.ConsolePrint("CurrencyConverter", "Current Currency: " + Config.ConfigData.DisplayCurrency);
-            switch (Config.ConfigData.DisplayCurrency)
+
+            if (LastResponse.rates.ContainsKey(Config.ConfigData.DisplayCurrency))
+                return amount * LastResponse.rates[Config.ConfigData.DisplayCurrency];
+            else
             {
-                case "AUD":
-                    return amount * LastResponse.rates.AUD;
-                case "BGN":
-                    return amount * LastResponse.rates.BGN;
-                case "BRL":
-                    return amount * LastResponse.rates.BRL;
-                case "CAD":
-                    return amount * LastResponse.rates.CAD;
-                case "CHF":
-                    return amount * LastResponse.rates.CHF;
-                case "CNY":
-                    return amount * LastResponse.rates.CNY;
-                case "CZK":
-                    return amount * LastResponse.rates.CZK;
-                case "DKK":
-                    return amount * LastResponse.rates.DKK;
-                case "GBP":
-                    return amount * LastResponse.rates.GBP;
-                case "HKD":
-                    return amount * LastResponse.rates.HKD;
-                case "HRK":
-                    return amount * LastResponse.rates.HRK;
-                case "HUF":
-                    return amount * LastResponse.rates.HUF;
-                case "IDR":
-                    return amount * LastResponse.rates.IDR;
-                case "ILS":
-                    return amount * LastResponse.rates.ILS;
-                case "INR":
-                    return amount * LastResponse.rates.INR;
-                case "JPY":
-                    return amount * LastResponse.rates.JPY;
-                case "KRW":
-                    return amount * LastResponse.rates.KRW;
-                case "MXN":
-                    return amount * LastResponse.rates.MXN;
-                case "MYR":
-                    return amount * LastResponse.rates.MYR;
-                case "NOK":
-                    return amount * LastResponse.rates.NOK;
-                case "NZD":
-                    return amount * LastResponse.rates.NZD;
-                case "PHP":
-                    return amount * LastResponse.rates.PHP;
-                case "PLN":
-                    return amount * LastResponse.rates.PLN;
-                case "RON":
-                    return amount * LastResponse.rates.RON;
-                case "RUB":
-                    return amount * LastResponse.rates.RUB;
-                case "SEK":
-                    return amount * LastResponse.rates.SEK;
-                case "SGD":
-                    return amount * LastResponse.rates.SGD;
-                case "THB":
-                    return amount * LastResponse.rates.THB;
-                case "TRY":
-                    return amount * LastResponse.rates.TRY;
-                case "ZAR":
-                    return amount * LastResponse.rates.ZAR;
-                case "EUR":
-                    return amount * LastResponse.rates.EUR;
-                default:
-                    Helpers.ConsolePrint("CurrencyConverter", "Currency Converter. Unable to retrieve rates. Fallback to USD");
-                    return amount;
+                Helpers.ConsolePrint("CurrencyConverter", "Unknown Currency Tag: " + Config.ConfigData.DisplayCurrency + " falling back to USD rates");
+                Config.ConfigData.DisplayCurrency = "USD";
+                return amount;
             }
         }
 
@@ -119,45 +61,12 @@ namespace NiceHashMiner.CurrencyConverter
     }
 
 
-    public class Rates
-    {
-        public double AUD { get; set; }
-        public double BGN { get; set; }
-        public double BRL { get; set; }
-        public double CAD { get; set; }
-        public double CHF { get; set; }
-        public double CNY { get; set; }
-        public double CZK { get; set; }
-        public double DKK { get; set; }
-        public double GBP { get; set; }
-        public double HKD { get; set; }
-        public double HRK { get; set; }
-        public double HUF { get; set; }
-        public double IDR { get; set; }
-        public double ILS { get; set; }
-        public double INR { get; set; }
-        public double JPY { get; set; }
-        public double KRW { get; set; }
-        public double MXN { get; set; }
-        public double MYR { get; set; }
-        public double NOK { get; set; }
-        public double NZD { get; set; }
-        public double PHP { get; set; }
-        public double PLN { get; set; }
-        public double RON { get; set; }
-        public double RUB { get; set; }
-        public double SEK { get; set; }
-        public double SGD { get; set; }
-        public double THB { get; set; }
-        public double TRY { get; set; }
-        public double ZAR { get; set; }
-        public double EUR { get; set; }
-    }
+    
 
     public class CurrencyAPIResponse
     {
         public string @base { get; set; }
         public string date { get; set; }
-        public Rates rates { get; set; }
+        public Dictionary<string, double> rates { get; set; }
     }
 }

--- a/NiceHashMiner/CurrencyConverter.cs
+++ b/NiceHashMiner/CurrencyConverter.cs
@@ -16,6 +16,9 @@ namespace NiceHashMiner.CurrencyConverter
 
         public static double ConvertToActiveCurrency(double amount)
         {
+            if (!ConverterActive)
+                return amount;
+
             if(LastResponse == null || DateTime.Now - LastUpdate > TimeSpan.FromMinutes(10))
             {
                 UpdateAPI();

--- a/NiceHashMiner/CurrencyConverter.cs
+++ b/NiceHashMiner/CurrencyConverter.cs
@@ -1,0 +1,160 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Net;
+
+namespace NiceHashMiner.CurrencyConverter
+{
+    public static class CurrencyConverter
+    {
+        public static DateTime LastUpdate = DateTime.Now;
+        public static CurrencyAPIResponse LastResponse;
+
+        public static bool ConverterActive  {
+            get { return Config.ConfigData.DisplayCurrency != "USD"; }
+        }
+
+
+        public static double ConvertToActiveCurrency(double amount)
+        {
+            if(LastResponse == null || DateTime.Now - LastUpdate > TimeSpan.FromMinutes(10))
+            {
+                UpdateAPI();
+            }
+
+            // if we are still null after an update something went wrong. just use USD hopefully itll update next tick
+            if (LastResponse == null)
+            {
+                Helpers.ConsolePrint("CurrencyConverter", "Unable to retrieve update, Falling back to USD");
+                return amount;
+            }
+
+            Helpers.ConsolePrint("CurrencyConverter", "Current Currency: " + Config.ConfigData.DisplayCurrency);
+            switch (Config.ConfigData.DisplayCurrency)
+            {
+                case "AUD":
+                    return amount * LastResponse.rates.AUD;
+                case "BGN":
+                    return amount * LastResponse.rates.BGN;
+                case "BRL":
+                    return amount * LastResponse.rates.BRL;
+                case "CAD":
+                    return amount * LastResponse.rates.CAD;
+                case "CHF":
+                    return amount * LastResponse.rates.CHF;
+                case "CNY":
+                    return amount * LastResponse.rates.CNY;
+                case "CZK":
+                    return amount * LastResponse.rates.CZK;
+                case "DKK":
+                    return amount * LastResponse.rates.DKK;
+                case "GBP":
+                    return amount * LastResponse.rates.GBP;
+                case "HKD":
+                    return amount * LastResponse.rates.HKD;
+                case "HRK":
+                    return amount * LastResponse.rates.HRK;
+                case "HUF":
+                    return amount * LastResponse.rates.HUF;
+                case "IDR":
+                    return amount * LastResponse.rates.IDR;
+                case "ILS":
+                    return amount * LastResponse.rates.ILS;
+                case "INR":
+                    return amount * LastResponse.rates.INR;
+                case "JPY":
+                    return amount * LastResponse.rates.JPY;
+                case "KRW":
+                    return amount * LastResponse.rates.KRW;
+                case "MXN":
+                    return amount * LastResponse.rates.MXN;
+                case "MYR":
+                    return amount * LastResponse.rates.MYR;
+                case "NOK":
+                    return amount * LastResponse.rates.NOK;
+                case "NZD":
+                    return amount * LastResponse.rates.NZD;
+                case "PHP":
+                    return amount * LastResponse.rates.PHP;
+                case "PLN":
+                    return amount * LastResponse.rates.PLN;
+                case "RON":
+                    return amount * LastResponse.rates.RON;
+                case "RUB":
+                    return amount * LastResponse.rates.RUB;
+                case "SEK":
+                    return amount * LastResponse.rates.SEK;
+                case "SGD":
+                    return amount * LastResponse.rates.SGD;
+                case "THB":
+                    return amount * LastResponse.rates.THB;
+                case "TRY":
+                    return amount * LastResponse.rates.TRY;
+                case "ZAR":
+                    return amount * LastResponse.rates.ZAR;
+                case "EUR":
+                    return amount * LastResponse.rates.EUR;
+                default:
+                    Helpers.ConsolePrint("CurrencyConverter", "Currency Converter. Unable to retrieve rates. Fallback to USD");
+                    return amount;
+            }
+        }
+
+        private static void UpdateAPI()
+        {
+            try {
+                var Client = new WebClient();
+                var Response = Client.DownloadString("http://api.fixer.io/latest?base=USD");
+                LastResponse = JsonConvert.DeserializeObject<CurrencyAPIResponse>(Response);
+                LastUpdate = DateTime.Now;
+            }
+            catch (Exception E)
+            {
+                Helpers.ConsolePrint("CurrencyConverter", "Unable to update API: reverting to usd");
+                Config.ConfigData.DisplayCurrency = "USD";
+            }
+        }
+    }
+
+
+    public class Rates
+    {
+        public double AUD { get; set; }
+        public double BGN { get; set; }
+        public double BRL { get; set; }
+        public double CAD { get; set; }
+        public double CHF { get; set; }
+        public double CNY { get; set; }
+        public double CZK { get; set; }
+        public double DKK { get; set; }
+        public double GBP { get; set; }
+        public double HKD { get; set; }
+        public double HRK { get; set; }
+        public double HUF { get; set; }
+        public double IDR { get; set; }
+        public double ILS { get; set; }
+        public double INR { get; set; }
+        public double JPY { get; set; }
+        public double KRW { get; set; }
+        public double MXN { get; set; }
+        public double MYR { get; set; }
+        public double NOK { get; set; }
+        public double NZD { get; set; }
+        public double PHP { get; set; }
+        public double PLN { get; set; }
+        public double RON { get; set; }
+        public double RUB { get; set; }
+        public double SEK { get; set; }
+        public double SGD { get; set; }
+        public double THB { get; set; }
+        public double TRY { get; set; }
+        public double ZAR { get; set; }
+        public double EUR { get; set; }
+    }
+
+    public class CurrencyAPIResponse
+    {
+        public string @base { get; set; }
+        public string date { get; set; }
+        public Rates rates { get; set; }
+    }
+}

--- a/NiceHashMiner/Form1.Designer.cs
+++ b/NiceHashMiner/Form1.Designer.cs
@@ -91,7 +91,7 @@
             // 
             // buttonStartMining
             // 
-            this.buttonStartMining.Location = new System.Drawing.Point(444, 146);
+            this.buttonStartMining.Location = new System.Drawing.Point(452, 146);
             this.buttonStartMining.Name = "buttonStartMining";
             this.buttonStartMining.Size = new System.Drawing.Size(89, 23);
             this.buttonStartMining.TabIndex = 6;
@@ -155,7 +155,7 @@
             this.toolStripStatusLabel10});
             this.statusStrip1.Location = new System.Drawing.Point(0, 267);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Size = new System.Drawing.Size(544, 25);
+            this.statusStrip1.Size = new System.Drawing.Size(553, 25);
             this.statusStrip1.TabIndex = 8;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -301,7 +301,7 @@
             // buttonStopMining
             // 
             this.buttonStopMining.Enabled = false;
-            this.buttonStopMining.Location = new System.Drawing.Point(444, 173);
+            this.buttonStopMining.Location = new System.Drawing.Point(452, 173);
             this.buttonStopMining.Name = "buttonStopMining";
             this.buttonStopMining.Size = new System.Drawing.Size(89, 23);
             this.buttonStopMining.TabIndex = 7;
@@ -425,7 +425,7 @@
             // 
             // buttonBenchmark
             // 
-            this.buttonBenchmark.Location = new System.Drawing.Point(444, 91);
+            this.buttonBenchmark.Location = new System.Drawing.Point(452, 91);
             this.buttonBenchmark.Name = "buttonBenchmark";
             this.buttonBenchmark.Size = new System.Drawing.Size(89, 23);
             this.buttonBenchmark.TabIndex = 4;
@@ -462,7 +462,7 @@
             // 
             // buttonSettings
             // 
-            this.buttonSettings.Location = new System.Drawing.Point(444, 118);
+            this.buttonSettings.Location = new System.Drawing.Point(452, 117);
             this.buttonSettings.Name = "buttonSettings";
             this.buttonSettings.Size = new System.Drawing.Size(89, 23);
             this.buttonSettings.TabIndex = 5;
@@ -570,7 +570,7 @@
             this.buttonHelp.FlatAppearance.BorderSize = 0;
             this.buttonHelp.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.buttonHelp.Image = global::NiceHashMiner.Properties.Resources.NHM_help_50px;
-            this.buttonHelp.Location = new System.Drawing.Point(473, 0);
+            this.buttonHelp.Location = new System.Drawing.Point(489, 0);
             this.buttonHelp.Name = "buttonHelp";
             this.buttonHelp.Size = new System.Drawing.Size(52, 60);
             this.buttonHelp.TabIndex = 11;
@@ -611,7 +611,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(544, 292);
+            this.ClientSize = new System.Drawing.Size(553, 292);
             this.Controls.Add(this.labelDemoMode);
             this.Controls.Add(this.linkLabelChooseBTCWallet);
             this.Controls.Add(this.buttonHelp);

--- a/NiceHashMiner/Form1.cs
+++ b/NiceHashMiner/Form1.cs
@@ -69,11 +69,13 @@ namespace NiceHashMiner
             label_RateNVIDIA2XBTC.Text = "0.00000000 BTC/" + International.GetText("Day");
             label_RateAMDBTC.Text = "0.00000000 BTC/" + International.GetText("Day");
 
-            label_RateCPUDollar.Text = "0.00 $/" + International.GetText("Day");
-            label_RateNVIDIA5XDollar.Text = "0.00 $/" + International.GetText("Day");
-            label_RateNVIDIA3XDollar.Text = "0.00 $/" + International.GetText("Day");
-            label_RateNVIDIA2XDollar.Text = "0.00 $/" + International.GetText("Day");
-            label_RateAMDDollar.Text = "0.00 $/" + International.GetText("Day");
+
+
+            label_RateCPUDollar.Text = String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
+            label_RateNVIDIA5XDollar.Text = String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
+            label_RateNVIDIA3XDollar.Text = String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
+            label_RateNVIDIA2XDollar.Text = String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
+            label_RateAMDDollar.Text = String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
 
             toolStripStatusLabelGlobalRateText.Text = International.GetText("form1_global_rate") + ":";
             toolStripStatusLabelBTCDayText.Text = "BTC/" + International.GetText("Day");
@@ -578,7 +580,8 @@ namespace NiceHashMiner
             labelCPU_Mining_Speed.Text = FormatSpeedOutput(speed) + aname;
             if (aname.Equals("hodl")) labelCPU_Mining_Speed.Text += "**";
             label_RateCPUBTC.Text = FormatPayingOutput(paying);
-            label_RateCPUDollar.Text = (paying * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture) + " $/" + International.GetText("Day");
+            label_RateCPUDollar.Text = CurrencyConverter.CurrencyConverter.ConvertToActiveCurrency(paying * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture)
+                + String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
             UpdateGlobalRate();
         }
 
@@ -587,7 +590,8 @@ namespace NiceHashMiner
         {
             labelNVIDIA2X_Mining_Speed.Text = FormatSpeedOutput(speed) + aname;
             label_RateNVIDIA2XBTC.Text = FormatPayingOutput(paying);
-            label_RateNVIDIA2XDollar.Text = (paying * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture) + " $/" + International.GetText("Day");
+            label_RateNVIDIA2XDollar.Text = CurrencyConverter.CurrencyConverter.ConvertToActiveCurrency(paying * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture)
+                + String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
             UpdateGlobalRate();
         }
 
@@ -596,7 +600,8 @@ namespace NiceHashMiner
         {
             labelNVIDIA3X_Mining_Speed.Text = FormatSpeedOutput(speed) + aname;
             label_RateNVIDIA3XBTC.Text = FormatPayingOutput(paying);
-            label_RateNVIDIA3XDollar.Text = (paying * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture) + " $/" + International.GetText("Day");
+            label_RateNVIDIA3XDollar.Text = CurrencyConverter.CurrencyConverter.ConvertToActiveCurrency(paying * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture)
+                + String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
             UpdateGlobalRate();
         }
 
@@ -605,7 +610,8 @@ namespace NiceHashMiner
         {
             labelNVIDIA5X_Mining_Speed.Text = FormatSpeedOutput(speed) + aname;
             label_RateNVIDIA5XBTC.Text = FormatPayingOutput(paying);
-            label_RateNVIDIA5XDollar.Text = (paying * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture) + " $/" + International.GetText("Day");
+            label_RateNVIDIA5XDollar.Text = CurrencyConverter.CurrencyConverter.ConvertToActiveCurrency(paying * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture) 
+                + String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
             UpdateGlobalRate();
         }
 
@@ -614,7 +620,8 @@ namespace NiceHashMiner
         {
             labelAMDOpenCL_Mining_Speed.Text = FormatSpeedOutput(speed) + aname;
             label_RateAMDBTC.Text = FormatPayingOutput(paying);
-            label_RateAMDDollar.Text = (paying * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture) + " $/" + International.GetText("Day");
+            label_RateAMDDollar.Text = CurrencyConverter.CurrencyConverter.ConvertToActiveCurrency(paying * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture)
+                + String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
             UpdateGlobalRate();
         }
 

--- a/NiceHashMiner/Form1.cs
+++ b/NiceHashMiner/Form1.cs
@@ -117,6 +117,9 @@ namespace NiceHashMiner
             textBoxWorkerName.Text = Config.ConfigData.WorkerName;
             ShowWarningNiceHashData = true;
             DemoMode = false;
+
+            if (CurrencyConverter.CurrencyConverter.ConverterActive)
+                toolStripStatusLabelBalanceDollarValue.Text = "(" + Config.ConfigData.DisplayCurrency + ")";
         }
 
 
@@ -655,8 +658,17 @@ namespace NiceHashMiner
                         toolStripStatusLabelBalanceBTCCode.Text = "BTC";
                         toolStripStatusLabelBalanceBTCValue.Text = Balance.ToString("F8", CultureInfo.InvariantCulture);
                     }
-
-                    toolStripStatusLabelBalanceDollarText.Text = (Balance * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture);
+                    
+                    Helpers.ConsolePrint("CurrencyConverter", "IsActive: " + CurrencyConverter.CurrencyConverter.ConverterActive);
+                    if(CurrencyConverter.CurrencyConverter.ConverterActive == false)
+                        toolStripStatusLabelBalanceDollarText.Text = (Balance * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture);
+                    else
+                    {
+                        Helpers.ConsolePrint("CurrencyConverter", "Using CurrencyConverter" + Config.ConfigData.DisplayCurrency);
+                        double Amount = (Balance * BitcoinRate);
+                        Amount = CurrencyConverter.CurrencyConverter.ConvertToActiveCurrency(Amount);
+                        toolStripStatusLabelBalanceDollarText.Text = Amount.ToString("F2", CultureInfo.InvariantCulture);
+                    }
                 }
             }
         }

--- a/NiceHashMiner/Form1.cs
+++ b/NiceHashMiner/Form1.cs
@@ -71,11 +71,11 @@ namespace NiceHashMiner
 
 
 
-            label_RateCPUDollar.Text = String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
-            label_RateNVIDIA5XDollar.Text = String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
-            label_RateNVIDIA3XDollar.Text = String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
-            label_RateNVIDIA2XDollar.Text = String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
-            label_RateAMDDollar.Text = String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
+            label_RateCPUDollar.Text = String.Format("0.00 {0}/", !CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
+            label_RateNVIDIA5XDollar.Text = String.Format("0.00 {0}/", !CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
+            label_RateNVIDIA3XDollar.Text = String.Format("0.00 {0}/", !CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
+            label_RateNVIDIA2XDollar.Text = String.Format("0.00 {0}/", !CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
+            label_RateAMDDollar.Text = String.Format("0.00 {0}/", !CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
 
             toolStripStatusLabelGlobalRateText.Text = International.GetText("form1_global_rate") + ":";
             toolStripStatusLabelBTCDayText.Text = "BTC/" + International.GetText("Day");
@@ -581,7 +581,7 @@ namespace NiceHashMiner
             if (aname.Equals("hodl")) labelCPU_Mining_Speed.Text += "**";
             label_RateCPUBTC.Text = FormatPayingOutput(paying);
             label_RateCPUDollar.Text = CurrencyConverter.CurrencyConverter.ConvertToActiveCurrency(paying * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture)
-                + String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
+                + String.Format(" {0}/", !CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
             UpdateGlobalRate();
         }
 
@@ -591,7 +591,7 @@ namespace NiceHashMiner
             labelNVIDIA2X_Mining_Speed.Text = FormatSpeedOutput(speed) + aname;
             label_RateNVIDIA2XBTC.Text = FormatPayingOutput(paying);
             label_RateNVIDIA2XDollar.Text = CurrencyConverter.CurrencyConverter.ConvertToActiveCurrency(paying * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture)
-                + String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
+                + String.Format(" {0}/", !CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
             UpdateGlobalRate();
         }
 
@@ -601,7 +601,7 @@ namespace NiceHashMiner
             labelNVIDIA3X_Mining_Speed.Text = FormatSpeedOutput(speed) + aname;
             label_RateNVIDIA3XBTC.Text = FormatPayingOutput(paying);
             label_RateNVIDIA3XDollar.Text = CurrencyConverter.CurrencyConverter.ConvertToActiveCurrency(paying * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture)
-                + String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
+                + String.Format(" {0}/", !CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
             UpdateGlobalRate();
         }
 
@@ -611,7 +611,7 @@ namespace NiceHashMiner
             labelNVIDIA5X_Mining_Speed.Text = FormatSpeedOutput(speed) + aname;
             label_RateNVIDIA5XBTC.Text = FormatPayingOutput(paying);
             label_RateNVIDIA5XDollar.Text = CurrencyConverter.CurrencyConverter.ConvertToActiveCurrency(paying * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture) 
-                + String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
+                + String.Format(" {0}/", !CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
             UpdateGlobalRate();
         }
 
@@ -621,7 +621,7 @@ namespace NiceHashMiner
             labelAMDOpenCL_Mining_Speed.Text = FormatSpeedOutput(speed) + aname;
             label_RateAMDBTC.Text = FormatPayingOutput(paying);
             label_RateAMDDollar.Text = CurrencyConverter.CurrencyConverter.ConvertToActiveCurrency(paying * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture)
-                + String.Format("0.00 {0}/", CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
+                + String.Format(" {0}/", !CurrencyConverter.CurrencyConverter.ConverterActive ? "$" : Config.ConfigData.DisplayCurrency) + International.GetText("Day");
             UpdateGlobalRate();
         }
 

--- a/NiceHashMiner/Form1.cs
+++ b/NiceHashMiner/Form1.cs
@@ -77,7 +77,7 @@ namespace NiceHashMiner
 
             toolStripStatusLabelGlobalRateText.Text = International.GetText("form1_global_rate") + ":";
             toolStripStatusLabelBTCDayText.Text = "BTC/" + International.GetText("Day");
-            toolStripStatusLabelBalanceText.Text = "$/" + International.GetText("Day") + "     " + International.GetText("form1_balance") + ":";
+            toolStripStatusLabelBalanceText.Text = (CurrencyConverter.CurrencyConverter.ConverterActive == false ? "$/" : Config.ConfigData.DisplayCurrency + "/") + International.GetText("Day") + "     " + International.GetText("form1_balance") + ":";
 
             listViewDevices.Columns[0].Text = International.GetText("ListView_Enabled");
             listViewDevices.Columns[1].Text = International.GetText("ListView_Group");
@@ -636,7 +636,14 @@ namespace NiceHashMiner
                 toolStripStatusLabelGlobalRateValue.Text = (TotalRate).ToString("F8", CultureInfo.InvariantCulture);
             }
 
-            toolStripStatusLabelBTCDayValue.Text = (TotalRate * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture);
+
+
+
+            if(CurrencyConverter.CurrencyConverter.ConverterActive == false)
+                toolStripStatusLabelBTCDayValue.Text = (TotalRate * BitcoinRate).ToString("F2", CultureInfo.InvariantCulture);
+            else
+
+                toolStripStatusLabelBTCDayValue.Text = CurrencyConverter.CurrencyConverter.ConvertToActiveCurrency((TotalRate * BitcoinRate)).ToString("F2", CultureInfo.InvariantCulture);
         }
 
 

--- a/NiceHashMiner/Form_Settings.Designer.cs
+++ b/NiceHashMiner/Form_Settings.Designer.cs
@@ -49,7 +49,7 @@
             this.comboBox_CPU0_ForceCPUExtension = new System.Windows.Forms.ComboBox();
             this.label_CPU0_ForceCPUExtension = new System.Windows.Forms.Label();
             this.tabPage1 = new System.Windows.Forms.TabPage();
-            this.label1 = new System.Windows.Forms.Label();
+            this.displayCurrencyLabel = new System.Windows.Forms.Label();
             this.currencyConverterCombobox = new System.Windows.Forms.ComboBox();
             this.textBox_MinerAPIGraceSecondsAMD = new System.Windows.Forms.TextBox();
             this.label_MinerAPIGraceSecondsAMD = new System.Windows.Forms.Label();
@@ -394,7 +394,7 @@
             // 
             // tabPage1
             // 
-            this.tabPage1.Controls.Add(this.label1);
+            this.tabPage1.Controls.Add(this.displayCurrencyLabel);
             this.tabPage1.Controls.Add(this.currencyConverterCombobox);
             this.tabPage1.Controls.Add(this.textBox_MinerAPIGraceSecondsAMD);
             this.tabPage1.Controls.Add(this.label_MinerAPIGraceSecondsAMD);
@@ -472,14 +472,14 @@
             this.tabPage1.Text = "General";
             this.tabPage1.UseVisualStyleBackColor = true;
             // 
-            // label1
+            // displayCurrencyLabel
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(550, 8);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(86, 13);
-            this.label1.TabIndex = 102;
-            this.label1.Text = "Display Currency";
+            this.displayCurrencyLabel.AutoSize = true;
+            this.displayCurrencyLabel.Location = new System.Drawing.Point(550, 8);
+            this.displayCurrencyLabel.Name = "displayCurrencyLabel";
+            this.displayCurrencyLabel.Size = new System.Drawing.Size(86, 13);
+            this.displayCurrencyLabel.TabIndex = 102;
+            this.displayCurrencyLabel.Text = "Display Currency";
             // 
             // currencyConverterCombobox
             // 
@@ -2061,7 +2061,7 @@
         private System.Windows.Forms.Label label_SwitchMinSecondsAMD;
         private System.Windows.Forms.TextBox textBox_MinerAPIGraceSecondsAMD;
         private System.Windows.Forms.Label label_MinerAPIGraceSecondsAMD;
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label displayCurrencyLabel;
         private System.Windows.Forms.ComboBox currencyConverterCombobox;
     }
 }

--- a/NiceHashMiner/Form_Settings.Designer.cs
+++ b/NiceHashMiner/Form_Settings.Designer.cs
@@ -49,6 +49,10 @@
             this.comboBox_CPU0_ForceCPUExtension = new System.Windows.Forms.ComboBox();
             this.label_CPU0_ForceCPUExtension = new System.Windows.Forms.Label();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.label1 = new System.Windows.Forms.Label();
+            this.currencyConverterCombobox = new System.Windows.Forms.ComboBox();
+            this.textBox_MinerAPIGraceSecondsAMD = new System.Windows.Forms.TextBox();
+            this.label_MinerAPIGraceSecondsAMD = new System.Windows.Forms.Label();
             this.textBox_SwitchMinSecondsAMD = new System.Windows.Forms.TextBox();
             this.label_SwitchMinSecondsAMD = new System.Windows.Forms.Label();
             this.checkBox_LogToFile = new System.Windows.Forms.CheckBox();
@@ -192,8 +196,6 @@
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.buttonDefaults = new System.Windows.Forms.Button();
             this.buttonSaveClose = new System.Windows.Forms.Button();
-            this.label_MinerAPIGraceSecondsAMD = new System.Windows.Forms.Label();
-            this.textBox_MinerAPIGraceSecondsAMD = new System.Windows.Forms.TextBox();
             this.tabPage2.SuspendLayout();
             this.tabControl_CPU0.SuspendLayout();
             this.tabPage7.SuspendLayout();
@@ -223,7 +225,7 @@
             this.tabPage2.Location = new System.Drawing.Point(4, 22);
             this.tabPage2.Name = "tabPage2";
             this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(893, 338);
+            this.tabPage2.Size = new System.Drawing.Size(900, 353);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "CPU0";
             this.tabPage2.UseVisualStyleBackColor = true;
@@ -392,6 +394,8 @@
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.label1);
+            this.tabPage1.Controls.Add(this.currencyConverterCombobox);
             this.tabPage1.Controls.Add(this.textBox_MinerAPIGraceSecondsAMD);
             this.tabPage1.Controls.Add(this.label_MinerAPIGraceSecondsAMD);
             this.tabPage1.Controls.Add(this.textBox_SwitchMinSecondsAMD);
@@ -467,6 +471,74 @@
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "General";
             this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(550, 8);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(86, 13);
+            this.label1.TabIndex = 102;
+            this.label1.Text = "Display Currency";
+            // 
+            // currencyConverterCombobox
+            // 
+            this.currencyConverterCombobox.FormattingEnabled = true;
+            this.currencyConverterCombobox.Items.AddRange(new object[] {
+            "AUD",
+            "BGN",
+            "BRL",
+            "CAD",
+            "CHF",
+            "CNY",
+            "CZK",
+            "DKK",
+            "EUR",
+            "GBP",
+            "HKD",
+            "HRK",
+            "HUF",
+            "IDR",
+            "ILS",
+            "INR",
+            "JPY",
+            "KRW",
+            "MXN",
+            "MYR",
+            "NOK",
+            "NZD",
+            "PHP",
+            "PLN",
+            "RON",
+            "RUB",
+            "SEK",
+            "SGD",
+            "THB",
+            "TRY",
+            "USD",
+            "ZAR"});
+            this.currencyConverterCombobox.Location = new System.Drawing.Point(550, 28);
+            this.currencyConverterCombobox.Name = "currencyConverterCombobox";
+            this.currencyConverterCombobox.Size = new System.Drawing.Size(121, 21);
+            this.currencyConverterCombobox.Sorted = true;
+            this.currencyConverterCombobox.TabIndex = 101;
+            this.currencyConverterCombobox.SelectedIndexChanged += new System.EventHandler(this.currencyConverterCombobox_SelectedIndexChanged);
+            // 
+            // textBox_MinerAPIGraceSecondsAMD
+            // 
+            this.textBox_MinerAPIGraceSecondsAMD.Location = new System.Drawing.Point(379, 176);
+            this.textBox_MinerAPIGraceSecondsAMD.Name = "textBox_MinerAPIGraceSecondsAMD";
+            this.textBox_MinerAPIGraceSecondsAMD.Size = new System.Drawing.Size(139, 20);
+            this.textBox_MinerAPIGraceSecondsAMD.TabIndex = 23;
+            // 
+            // label_MinerAPIGraceSecondsAMD
+            // 
+            this.label_MinerAPIGraceSecondsAMD.AutoSize = true;
+            this.label_MinerAPIGraceSecondsAMD.Location = new System.Drawing.Point(376, 155);
+            this.label_MinerAPIGraceSecondsAMD.Name = "label_MinerAPIGraceSecondsAMD";
+            this.label_MinerAPIGraceSecondsAMD.Size = new System.Drawing.Size(148, 13);
+            this.label_MinerAPIGraceSecondsAMD.TabIndex = 100;
+            this.label_MinerAPIGraceSecondsAMD.Text = "MinerAPIGraceSecondsAMD:";
             // 
             // textBox_SwitchMinSecondsAMD
             // 
@@ -1040,8 +1112,8 @@
             // 
             // tabControl1
             // 
-            this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-            | System.Windows.Forms.AnchorStyles.Left)
+            this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControl1.Controls.Add(this.tabPage1);
             this.tabControl1.Controls.Add(this.tabPage2);
@@ -1072,7 +1144,7 @@
             this.tabPage_NVIDIA5X.Location = new System.Drawing.Point(4, 22);
             this.tabPage_NVIDIA5X.Name = "tabPage_NVIDIA5X";
             this.tabPage_NVIDIA5X.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage_NVIDIA5X.Size = new System.Drawing.Size(893, 338);
+            this.tabPage_NVIDIA5X.Size = new System.Drawing.Size(900, 353);
             this.tabPage_NVIDIA5X.TabIndex = 2;
             this.tabPage_NVIDIA5X.Text = "NVIDIA5X";
             this.tabPage_NVIDIA5X.UseVisualStyleBackColor = true;
@@ -1196,7 +1268,7 @@
             this.tabPage_NVIDIA3X.Location = new System.Drawing.Point(4, 22);
             this.tabPage_NVIDIA3X.Name = "tabPage_NVIDIA3X";
             this.tabPage_NVIDIA3X.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage_NVIDIA3X.Size = new System.Drawing.Size(893, 338);
+            this.tabPage_NVIDIA3X.Size = new System.Drawing.Size(900, 353);
             this.tabPage_NVIDIA3X.TabIndex = 3;
             this.tabPage_NVIDIA3X.Text = "NVIDIA3X";
             this.tabPage_NVIDIA3X.UseVisualStyleBackColor = true;
@@ -1321,7 +1393,7 @@
             this.tabPage_NVIDIA2X.Location = new System.Drawing.Point(4, 22);
             this.tabPage_NVIDIA2X.Name = "tabPage_NVIDIA2X";
             this.tabPage_NVIDIA2X.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage_NVIDIA2X.Size = new System.Drawing.Size(893, 338);
+            this.tabPage_NVIDIA2X.Size = new System.Drawing.Size(900, 353);
             this.tabPage_NVIDIA2X.TabIndex = 4;
             this.tabPage_NVIDIA2X.Text = "NVIDIA2X";
             this.tabPage_NVIDIA2X.UseVisualStyleBackColor = true;
@@ -1524,7 +1596,7 @@
             this.tabPage_AMD.Location = new System.Drawing.Point(4, 22);
             this.tabPage_AMD.Name = "tabPage_AMD";
             this.tabPage_AMD.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage_AMD.Size = new System.Drawing.Size(893, 338);
+            this.tabPage_AMD.Size = new System.Drawing.Size(900, 353);
             this.tabPage_AMD.TabIndex = 5;
             this.tabPage_AMD.Text = "AMD_OpenCL";
             this.tabPage_AMD.UseVisualStyleBackColor = true;
@@ -1779,22 +1851,6 @@
             this.buttonSaveClose.UseVisualStyleBackColor = true;
             this.buttonSaveClose.Click += new System.EventHandler(this.buttonSaveClose_Click);
             // 
-            // label_MinerAPIGraceSecondsAMD
-            // 
-            this.label_MinerAPIGraceSecondsAMD.AutoSize = true;
-            this.label_MinerAPIGraceSecondsAMD.Location = new System.Drawing.Point(376, 155);
-            this.label_MinerAPIGraceSecondsAMD.Name = "label_MinerAPIGraceSecondsAMD";
-            this.label_MinerAPIGraceSecondsAMD.Size = new System.Drawing.Size(148, 13);
-            this.label_MinerAPIGraceSecondsAMD.TabIndex = 100;
-            this.label_MinerAPIGraceSecondsAMD.Text = "MinerAPIGraceSecondsAMD:";
-            // 
-            // textBox_MinerAPIGraceSecondsAMD
-            // 
-            this.textBox_MinerAPIGraceSecondsAMD.Location = new System.Drawing.Point(379, 176);
-            this.textBox_MinerAPIGraceSecondsAMD.Name = "textBox_MinerAPIGraceSecondsAMD";
-            this.textBox_MinerAPIGraceSecondsAMD.Size = new System.Drawing.Size(139, 20);
-            this.textBox_MinerAPIGraceSecondsAMD.TabIndex = 23;
-            // 
             // Form_Settings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -2005,5 +2061,7 @@
         private System.Windows.Forms.Label label_SwitchMinSecondsAMD;
         private System.Windows.Forms.TextBox textBox_MinerAPIGraceSecondsAMD;
         private System.Windows.Forms.Label label_MinerAPIGraceSecondsAMD;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.ComboBox currencyConverterCombobox;
     }
 }

--- a/NiceHashMiner/Form_Settings.cs
+++ b/NiceHashMiner/Form_Settings.cs
@@ -104,6 +104,11 @@ namespace NiceHashMiner
             toolTip1.SetToolTip(this.label_ethminerAPIPortAMD, String.Format(International.GetText("Form_Settings_ToolTip_ethminerAPIPort"), "AMD"));
             toolTip1.SetToolTip(this.textBox_ethminerDefaultBlockHeight, International.GetText("Form_Settings_ToolTip_ethminerDefaultBlockHeight"));
             toolTip1.SetToolTip(this.label_ethminerDefaultBlockHeight, International.GetText("Form_Settings_ToolTip_ethminerDefaultBlockHeight"));
+
+            if (CurrencyConverter.CurrencyConverter.ConverterActive)
+                currencyConverterCombobox.SelectedItem = Config.ConfigData.DisplayCurrency;
+            else
+                currencyConverterCombobox.SelectedItem = "USD";
         }
 
         private void SetupGeneralTab()
@@ -257,6 +262,8 @@ namespace NiceHashMiner
             // Add EventHandler for all the general tab's textboxes
             this.comboBox_Language.Leave += new System.EventHandler(this.GeneralComboBoxes_Leave);
             this.comboBox_ServiceLocation.Leave += new System.EventHandler(this.GeneralComboBoxes_Leave);
+
+            currencyConverterCombobox.SelectedText = Config.ConfigData.DisplayCurrency;
         }
 
         // Currently it only supports for CPU0
@@ -1118,6 +1125,13 @@ namespace NiceHashMiner
                 if (result == System.Windows.Forms.DialogResult.No)
                     e.Cancel = true;
             }
+        }
+
+        private void currencyConverterCombobox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            Helpers.ConsolePrint("CurrencyConverter", "Currency Set to: " + currencyConverterCombobox.SelectedItem);
+            var Selected = currencyConverterCombobox.SelectedItem.ToString();
+            Config.ConfigData.DisplayCurrency = Selected;
         }
     }
 }

--- a/NiceHashMiner/Form_Settings.cs
+++ b/NiceHashMiner/Form_Settings.cs
@@ -109,6 +109,9 @@ namespace NiceHashMiner
                 currencyConverterCombobox.SelectedItem = Config.ConfigData.DisplayCurrency;
             else
                 currencyConverterCombobox.SelectedItem = "USD";
+
+
+            displayCurrencyLabel.Text = International.GetText("Form_Settings_DisplayCurrency");
         }
 
         private void SetupGeneralTab()

--- a/NiceHashMiner/NiceHashMiner.csproj
+++ b/NiceHashMiner/NiceHashMiner.csproj
@@ -70,6 +70,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CurrencyConverter.cs" />
     <Compile Include="ethminerAPI.cs" />
     <Compile Include="Form_ChooseLanguage.cs">
       <SubType>Form</SubType>

--- a/NiceHashMiner/langs/en.lang
+++ b/NiceHashMiner/langs/en.lang
@@ -231,6 +231,7 @@
         "Form_Settings_ToolTip_AlgoUsePassword": "Use this password when launching miner and this algorithm. If not set, Groups's UsePassword is used.",
         "Form_Settings_ToolTip_AlgoBenchmarkSpeed": "Fine tune algorithm ratios by manually setting benchmark speeds for each algorithm.",
         "Form_Settings_ToolTip_AlgoDisabledDevices": "Any devices that are checked will be skipped by NiceHashMiner (only for this algorithm).",
-        "Form_Settings_ToolTip_AlgoExtraLaunchParameters": "Additional launch parameters when launching miner and this algorithm."
+        "Form_Settings_ToolTip_AlgoExtraLaunchParameters": "Additional launch parameters when launching miner and this algorithm.",
+        "Form_Settings_DisplayCurrency":  "Display Currency"
     }
 }

--- a/NiceHashMiner/langs/es.lang
+++ b/NiceHashMiner/langs/es.lang
@@ -230,6 +230,7 @@
         "Form_Settings_ToolTip_AlgoUsePassword": "Usa esta contraseña al iniciar este minero y este algoritmo. Si no se establece, UsePassword del grupo se usará.",
         "Form_Settings_ToolTip_AlgoBenchmarkSpeed": "Personalización de los ratios de los algoritmos al cambiar manualmente las velocidades de los benchmark.",
         "Form_Settings_ToolTip_AlgoDisabledDevices": "Todos los dispositivos marcados serán ignorados por NiceHash Miner (solo para este algoritmo).",
-        "Form_Settings_ToolTip_AlgoExtraLaunchParameters": "Parámetros de inicio adicionales al lanzar el minero y este algoritmo."
+        "Form_Settings_ToolTip_AlgoExtraLaunchParameters": "Parámetros de inicio adicionales al lanzar el minero y este algoritmo.",
+        "Form_Settings_DisplayCurrency":  "Presentación de moneda"
     }
 }

--- a/NiceHashMiner/langs/ru.lang
+++ b/NiceHashMiner/langs/ru.lang
@@ -196,6 +196,7 @@
       "Form_Settings_ToolTip_AlgoUsePassword":"Использовать этот пароль при запуске майнера и этого алгоритма. Если не указано, будет использоваться пароль группы.",
       "Form_Settings_ToolTip_AlgoBenchmarkSpeed":"Ручная настройка скорости бенчмарка для каждого алгоритма.",
       "Form_Settings_ToolTip_AlgoDisabledDevices":"Отмеченные устройства будут пропущены NiceHashMiner (только для этого алгоритма).",
-      "Form_Settings_ToolTip_AlgoExtraLaunchParameters":"Дополнительные параметры при запуске майнера и этого алгоритма."
+      "Form_Settings_ToolTip_AlgoExtraLaunchParameters": "Дополнительные параметры при запуске майнера и этого алгоритма.",
+      "Form_Settings_DisplayCurrency":  "Дисплей валюты"
    }
 }

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Parameter | Range | Description
 ConfigFileVersion | Version | This is to identify which version of NiceHashMiner did the config file is made from.
 Language | number | Language selection for NiceHashMiner GUI.
 DebugConsole | true or false | When set to true, it displays debug console.
+DisplayCurrency | valid 3 letter code | Converts to selected currency via http://fixer.io valid options are any supported via fixer.
 BitcoinAddress | valid BTC address | The address that NiceHashMiner will mine to.
 WorkerName | text | To identify the computer on NiceHash web UI.
 Location | number | Used to select the location of the mining server.


### PR DESCRIPTION
Added a basic Currency Converter. Using data from http://fixer.io 

Added a dropdown to the settings page to select a currency, Defaults to USD: 

![image](https://cloud.githubusercontent.com/assets/569929/16747566/7d10e69a-47b7-11e6-8c6b-4774b0c0f4cc.png)

When a currency other than usd is select it shows a converted value on the main form. along with the currency "name" in brackets, 

![image](https://cloud.githubusercontent.com/assets/569929/16761614/cf931ca6-4818-11e6-8507-3eb3f1ee36f3.png)

Defaults to using USD values whenever anything goes wrong.

Code should be easy enough to understand.  Has been tested on a couple of machines I own.  But was only written in an hour or so.  

Translations provided via Google Translate. 
