### PR TITLE
Implementation of Claymore's Ethereum miner

### DIFF
--- a/NiceHashMiner/Miners/ClaymoreBaseMiner.cs
+++ b/NiceHashMiner/Miners/ClaymoreBaseMiner.cs
@@ -15,8 +15,7 @@ using System.Threading;
 
 namespace NiceHashMiner.Miners {
     public abstract class ClaymoreBaseMiner : Miner {
-
-        const int benchmarkTimeWait = 45; // if this is larger then welcome to hell!!! keep this fixed
+        
         int benchmark_read_count = 0;
         double benchmark_sum = 0.0d;
         protected readonly string LOOK_FOR_START;
@@ -25,6 +24,7 @@ namespace NiceHashMiner.Miners {
         // only dagger change
         protected bool ignoreZero = false;
         protected double api_read_mult = 1;
+        protected int benchmarkTimeWait = 45;
 
         public ClaymoreBaseMiner(string minerDeviceName, string look_FOR_START)
             : base(minerDeviceName) {
@@ -156,7 +156,7 @@ namespace NiceHashMiner.Miners {
                     //string outdata = BenchmarkHandle.StandardOutput.ReadLine();
                     //BenchmarkOutputErrorDataReceivedImpl(outdata);
                     // terminate process situations
-                    if (_benchmarkTimer.Elapsed.Seconds >= (benchmarkTimeWait + 2)
+                    if (_benchmarkTimer.Elapsed.TotalSeconds >= (benchmarkTimeWait + 2)
                         || BenchmarkSignalQuit
                         || BenchmarkSignalFinnished
                         || BenchmarkSignalHanged

--- a/NiceHashMiner/Miners/ClaymoreDual.cs
+++ b/NiceHashMiner/Miners/ClaymoreDual.cs
@@ -13,6 +13,7 @@ namespace NiceHashMiner.Miners {
             ignoreZero = true;
             api_read_mult = 1000;
             ConectionType = NHMConectionType.STRATUM_TCP;
+            benchmarkTimeWait = 90;
         }
 
         protected override int GET_MAX_CooldownTimeInMilliseconds() {

--- a/NiceHashMiner/Miners/ClaymoreDual.cs
+++ b/NiceHashMiner/Miners/ClaymoreDual.cs
@@ -27,7 +27,7 @@ namespace NiceHashMiner.Miners {
             }
             return " "
                 + GetDevicesCommandString()
-                + String.Format("-epool {0} -ewal {1} -mport -{2} -eworker {3} -esm 3 -epsw x -mode 1 -allpools 1", url, btcAdress, APIPort, useWorker);
+                + String.Format(" -epool {0} -ewal {1} -mport -{2} -eworker {3} -esm 3 -epsw x -mode 1 -allpools 1", url, btcAdress, APIPort, useWorker);
         }
 
         public override void Start(string url, string btcAdress, string worker) {


### PR DESCRIPTION
I added support for Claymore's eth miner - no dual algo or NVIDIA support though

It assumes the miner is in the bin_3rdparty folder under a folder called "claymore_ethereum"

I tried to keep any changes as similar to existing language as possible, but some abstraction needed to be added to ClaymoreBaseMiner since the eth miner handles some things differently than the Equihash/CN miners do (mainly reporting of hashrate as MH/s and no SSL support)

I also had to increase the benchmark time since 45s is barely enough to generate any hashes, required a bit of extra logic for the timer but I'm not sure if the "welcome to hell" comment was referring to anything else. Still at 45s for CN/Eq

Tested on two rigs, one with a Fury X and another with 2 290Xs, no issues

Issue #547 