### PR TITLE
Add "clear speed" button to context menu in benchmark

### DIFF
--- a/NiceHashMiner/Forms/Components/AlgorithmSettingsControl.cs
+++ b/NiceHashMiner/Forms/Components/AlgorithmSettingsControl.cs
@@ -92,6 +92,17 @@ namespace NiceHashMiner.Forms.Components {
             }
         }
 
+        public void ChangeSpeed(ListViewItem lvi)
+        {
+            if (Object.ReferenceEquals(_currentlySelectedLvi, lvi))
+            {
+                var algorithm = lvi.Tag as Algorithm;
+                if (algorithm != null) {
+                    fieldBoxBenchmarkSpeed.EntryText = ParseDoubleDefault(algorithm.BenchmarkSpeed);
+                }
+            }
+        }
+
         private bool CanEdit() {
             return _currentlySelectedAlgorithm != null && _selected;
         }

--- a/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
+++ b/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
@@ -212,7 +212,11 @@ namespace NiceHashMiner.Forms.Components {
         }
 
         private void toolStripMenuItemClear_Click(object sender, EventArgs e) {
-            // Do something
+            foreach (ListViewItem lvi in listViewAlgorithms.SelectedItems) {
+                var algorithm = lvi.Tag as Algorithm;
+                algorithm.BenchmarkSpeed = 0;
+                RepaintStatus(_computeDevice.Enabled, _computeDevice.UUID);
+            }
         }
 
     }

--- a/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
+++ b/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
@@ -214,11 +214,9 @@ namespace NiceHashMiner.Forms.Components {
 
         private void toolStripMenuItemClear_Click(object sender, EventArgs e) {
             if (_computeDevice != null) {
-                foreach (ListViewItem lvi in listViewAlgorithms.SelectedItems)
-                {
+                foreach (ListViewItem lvi in listViewAlgorithms.SelectedItems) {
                     var algorithm = lvi.Tag as Algorithm;
-                    if (algorithm != null)
-                    {
+                    if (algorithm != null) {
                         algorithm.BenchmarkSpeed = 0;
                         RepaintStatus(_computeDevice.Enabled, _computeDevice.UUID);
                         // update benchmark status data

--- a/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
+++ b/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
@@ -221,7 +221,7 @@ namespace NiceHashMiner.Forms.Components {
                     // update benchmark status data
                     if (BenchmarkCalculation != null) BenchmarkCalculation.CalcBenchmarkDevicesAlgorithmQueue();
                     // update settings
-                    ComunicationInterface.ChangeSpeed(lvi);
+                    if (ComunicationInterface != null) ComunicationInterface.ChangeSpeed(lvi);
                 }
             }
         }

--- a/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
+++ b/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
@@ -216,6 +216,8 @@ namespace NiceHashMiner.Forms.Components {
                 var algorithm = lvi.Tag as Algorithm;
                 algorithm.BenchmarkSpeed = 0;
                 RepaintStatus(_computeDevice.Enabled, _computeDevice.UUID);
+                // update benchmark status data
+                if (BenchmarkCalculation != null) BenchmarkCalculation.CalcBenchmarkDevicesAlgorithmQueue();
             }
         }
 

--- a/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
+++ b/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
@@ -213,15 +213,19 @@ namespace NiceHashMiner.Forms.Components {
         }
 
         private void toolStripMenuItemClear_Click(object sender, EventArgs e) {
-            foreach (ListViewItem lvi in listViewAlgorithms.SelectedItems) {
-                var algorithm = lvi.Tag as Algorithm;
-                if (algorithm != null) {
-                    algorithm.BenchmarkSpeed = 0;
-                    RepaintStatus(_computeDevice.Enabled, _computeDevice.UUID);
-                    // update benchmark status data
-                    if (BenchmarkCalculation != null) BenchmarkCalculation.CalcBenchmarkDevicesAlgorithmQueue();
-                    // update settings
-                    if (ComunicationInterface != null) ComunicationInterface.ChangeSpeed(lvi);
+            if (_computeDevice != null) {
+                foreach (ListViewItem lvi in listViewAlgorithms.SelectedItems)
+                {
+                    var algorithm = lvi.Tag as Algorithm;
+                    if (algorithm != null)
+                    {
+                        algorithm.BenchmarkSpeed = 0;
+                        RepaintStatus(_computeDevice.Enabled, _computeDevice.UUID);
+                        // update benchmark status data
+                        if (BenchmarkCalculation != null) BenchmarkCalculation.CalcBenchmarkDevicesAlgorithmQueue();
+                        // update settings
+                        if (ComunicationInterface != null) ComunicationInterface.ChangeSpeed(lvi);
+                    }
                 }
             }
         }

--- a/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
+++ b/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
@@ -24,6 +24,7 @@ namespace NiceHashMiner.Forms.Components {
         public interface IAlgorithmsListView {
             void SetCurrentlySelected(ListViewItem lvi, ComputeDevice computeDevice);
             void HandleCheck(ListViewItem lvi);
+            void ChangeSpeed(ListViewItem lvi);
         }
 
         public IAlgorithmsListView ComunicationInterface { get; set; }
@@ -214,10 +215,14 @@ namespace NiceHashMiner.Forms.Components {
         private void toolStripMenuItemClear_Click(object sender, EventArgs e) {
             foreach (ListViewItem lvi in listViewAlgorithms.SelectedItems) {
                 var algorithm = lvi.Tag as Algorithm;
-                algorithm.BenchmarkSpeed = 0;
-                RepaintStatus(_computeDevice.Enabled, _computeDevice.UUID);
-                // update benchmark status data
-                if (BenchmarkCalculation != null) BenchmarkCalculation.CalcBenchmarkDevicesAlgorithmQueue();
+                if (algorithm != null) {
+                    algorithm.BenchmarkSpeed = 0;
+                    RepaintStatus(_computeDevice.Enabled, _computeDevice.UUID);
+                    // update benchmark status data
+                    if (BenchmarkCalculation != null) BenchmarkCalculation.CalcBenchmarkDevicesAlgorithmQueue();
+                    // update settings
+                    ComunicationInterface.ChangeSpeed(lvi);
+                }
             }
         }
 

--- a/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
+++ b/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
@@ -188,6 +188,13 @@ namespace NiceHashMiner.Forms.Components {
                     enableAllItems.Click += toolStripMenuItemEnableAll_Click;
                     contextMenuStrip1.Items.Add(enableAllItems);
                 }
+                // clear item
+                {
+                    var clearItem = new ToolStripMenuItem();
+                    clearItem.Text = International.GetText("AlgorithmsListView_ContextMenu_ClearItem");
+                    clearItem.Click += toolStripMenuItemClear_Click;
+                    contextMenuStrip1.Items.Add(clearItem);
+                }
                 contextMenuStrip1.Show(Cursor.Position);
             }
         }
@@ -202,6 +209,10 @@ namespace NiceHashMiner.Forms.Components {
             foreach (ListViewItem lvi in listViewAlgorithms.Items) {
                 lvi.Checked = false;
             }
+        }
+
+        private void toolStripMenuItemClear_Click(object sender, EventArgs e) {
+            // Do something
         }
 
     }

--- a/NiceHashMiner/langs/en.lang
+++ b/NiceHashMiner/langs/en.lang
@@ -323,6 +323,7 @@
         "Form_Settings_Text_DisableDefaultOptimizations": "Disable Default Optimizations",
         "AlgorithmsListView_ContextMenu_DisableAll": "Disable All Algorithms",
         "AlgorithmsListView_ContextMenu_EnableAll": "Enable All Algorithms",
+        "AlgorithmsListView_ContextMenu_ClearItem":  "Clear item speed",
         "Form_Main_No_Device_Enabled_For_Mining": "Warning no device has been enabled for mining, please enable at least 1 device to proceed mining.",
         "Form_Main_3rdParty_Title": "Disclaimer on usage of 3rd party software",
         "Form_Main_3rdParty_Text": "We have integrated 3rd party mining software (developed by Claymore) that should speed up your mining and give you more stable mining experience - this could potentially result in more earnings over a shorter period of time even after developer's fee is deducted. However, since this is 3rd party software that is fully closed-source, we have no chance to inspect it in any way. NiceHash can not vouch for using that software and is refusing to take any responsibility for any damage caused - security breaches, loss of data or funds, system or hardware error, and other issues. By agreeing to this disclaimer you take full responsibility for using these Claymore closed-source miners as they are.",

--- a/NiceHashMiner/langs/en.lang
+++ b/NiceHashMiner/langs/en.lang
@@ -323,7 +323,7 @@
         "Form_Settings_Text_DisableDefaultOptimizations": "Disable Default Optimizations",
         "AlgorithmsListView_ContextMenu_DisableAll": "Disable All Algorithms",
         "AlgorithmsListView_ContextMenu_EnableAll": "Enable All Algorithms",
-        "AlgorithmsListView_ContextMenu_ClearItem":  "Clear item speed",
+        "AlgorithmsListView_ContextMenu_ClearItem":  "Clear Algorithm Speed",
         "Form_Main_No_Device_Enabled_For_Mining": "Warning no device has been enabled for mining, please enable at least 1 device to proceed mining.",
         "Form_Main_3rdParty_Title": "Disclaimer on usage of 3rd party software",
         "Form_Main_3rdParty_Text": "We have integrated 3rd party mining software (developed by Claymore) that should speed up your mining and give you more stable mining experience - this could potentially result in more earnings over a shorter period of time even after developer's fee is deducted. However, since this is 3rd party software that is fully closed-source, we have no chance to inspect it in any way. NiceHash can not vouch for using that software and is refusing to take any responsibility for any damage caused - security breaches, loss of data or funds, system or hardware error, and other issues. By agreeing to this disclaimer you take full responsibility for using these Claymore closed-source miners as they are.",

--- a/NiceHashMiner/langs/es.lang
+++ b/NiceHashMiner/langs/es.lang
@@ -322,7 +322,7 @@
 		"Form_Settings_Text_DisableDefaultOptimizations": "Desactivar optimizaciones predeterminadas",
 		"AlgorithmsListView_ContextMenu_DisableAll": "Deshabilitar todos los algoritmos",
 		"AlgorithmsListView_ContextMenu_EnableAll": "Habilitar todos los algoritmos",
-        "AlgorithmsListView_ContextMenu_ClearItem": "Velocidad del artículo",
+    "AlgorithmsListView_ContextMenu_ClearItem": "Velocidad del Algoritmo Limpio",
 		"Form_Main_No_Device_Enabled_For_Mining": "¡Alerta! Ningún dispisitivo se ha establecido para minar, por favor habilite al menos 1 dispositivo para poder minar.",
 		"Form_Main_3rdParty_Title": "Aviso en el uso de software de terceros",
 		"Form_Main_3rdParty_Text": "Hemos integrado software de minado de terceros (desarrollado por Claymore) que debería aumentar su verlocidad y estabilidad minando - esto podría resultar en mas beneficios en un menor periodo de tiempo después de la regalía del desarrollador. Aun así, dado que no es de código abierto, no podemos inspeccionarlo de ninguna forma. NiceHash no puede garantizar el uso de ese software y se niega a asumir ninguna responsabilidad por cualquier daño causado - incumplimientos de seguridad, pérdida de datos o fondos, errores de sistema o hardware y otros problemas. Al aceptar esta exención de responsabilidad usted asume toda la responsabilidad de usar estos mineros cerrados de Claymore como son.",

--- a/NiceHashMiner/langs/es.lang
+++ b/NiceHashMiner/langs/es.lang
@@ -322,6 +322,7 @@
 		"Form_Settings_Text_DisableDefaultOptimizations": "Desactivar optimizaciones predeterminadas",
 		"AlgorithmsListView_ContextMenu_DisableAll": "Deshabilitar todos los algoritmos",
 		"AlgorithmsListView_ContextMenu_EnableAll": "Habilitar todos los algoritmos",
+        "AlgorithmsListView_ContextMenu_ClearItem": "Velocidad del artículo",
 		"Form_Main_No_Device_Enabled_For_Mining": "¡Alerta! Ningún dispisitivo se ha establecido para minar, por favor habilite al menos 1 dispositivo para poder minar.",
 		"Form_Main_3rdParty_Title": "Aviso en el uso de software de terceros",
 		"Form_Main_3rdParty_Text": "Hemos integrado software de minado de terceros (desarrollado por Claymore) que debería aumentar su verlocidad y estabilidad minando - esto podría resultar en mas beneficios en un menor periodo de tiempo después de la regalía del desarrollador. Aun así, dado que no es de código abierto, no podemos inspeccionarlo de ninguna forma. NiceHash no puede garantizar el uso de ese software y se niega a asumir ninguna responsabilidad por cualquier daño causado - incumplimientos de seguridad, pérdida de datos o fondos, errores de sistema o hardware y otros problemas. Al aceptar esta exención de responsabilidad usted asume toda la responsabilidad de usar estos mineros cerrados de Claymore como son.",

--- a/NiceHashMiner/langs/ru.lang
+++ b/NiceHashMiner/langs/ru.lang
@@ -254,7 +254,7 @@
         "AlgorithmsListView_GroupBox_NONE": "NONE",
 	"AlgorithmsListView_ContextMenu_DisableAll": "Отключить все алгоритмы",
         "AlgorithmsListView_ContextMenu_EnableAll" : "Включить все алгоритмы",
-        "AlgorithmsListView_ContextMenu_ClearItem": "ясно скорость пункт",
+        "AlgorithmsListView_ContextMenu_ClearItem": "Быстрая скорость алгоритма",
         "BenchmarkOptions_Benchmark_Type": "Тип бенчмарка:",
         "Form_Main_MiningDevices": "Устройства {0}:",
         "Form_Main_bins_folder_files_missing": "Отсутствуют файлы с последней инициализации майнеров. Убедитесь, что ваш антивирус не блокирует приложение. NiceHash Miner может не работать правильно без недостающих файлов. Нажмите Да для переустановки NiceHash Miner, чтобы попробовать исправить ошибку.",

--- a/NiceHashMiner/langs/ru.lang
+++ b/NiceHashMiner/langs/ru.lang
@@ -254,6 +254,7 @@
         "AlgorithmsListView_GroupBox_NONE": "NONE",
 	"AlgorithmsListView_ContextMenu_DisableAll": "Отключить все алгоритмы",
         "AlgorithmsListView_ContextMenu_EnableAll" : "Включить все алгоритмы",
+        "AlgorithmsListView_ContextMenu_ClearItem": "ясно скорость пункт",
         "BenchmarkOptions_Benchmark_Type": "Тип бенчмарка:",
         "Form_Main_MiningDevices": "Устройства {0}:",
         "Form_Main_bins_folder_files_missing": "Отсутствуют файлы с последней инициализации майнеров. Убедитесь, что ваш антивирус не блокирует приложение. NiceHash Miner может не работать правильно без недостающих файлов. Нажмите Да для переустановки NiceHash Miner, чтобы попробовать исправить ошибку.",


### PR DESCRIPTION
Quite often I find myself having to exit the benchmark screen, navigate to the algo settings, and set an algo to 0 speed, so I can have it rebenchmarked (e.g. new miner came out, new OC, etc). Or, unselecting everything except the one and hit "benchmark all"

This adds an option in the right click menu that will set the selected algo to no speed right away

I used Google translate for the Russian/Spanish translations so if anyone's got something better that'd be great