### PR TITLE
Dual algo profit switching

### DIFF
--- a/NiceHashMiner/Algorithm.cs
+++ b/NiceHashMiner/Algorithm.cs
@@ -26,6 +26,7 @@ namespace NiceHashMiner {
 
         // avarage speed of same devices to increase mining stability
         public double AvaragedSpeed { get; set; }
+        public double SecondaryAveragedSpeed { get; set; }
         // based on device and settings here we set the miner path
         public string MinerBinaryPath = "";
         // these are changing (logging reasons)
@@ -90,8 +91,8 @@ namespace NiceHashMiner {
                 string rate = International.GetText("BenchmarkRatioRateN_A");
                 var payingRate = 0.0d;
                 if (Globals.NiceHashData != null) {
-                    rate = (BenchmarkSpeed * Globals.NiceHashData[NiceHashID].paying * 0.000000001).ToString("F8");
-                    if (BenchmarkSpeed > 0)  {
+                    if (BenchmarkSpeed > 0)
+                    {
                         payingRate += BenchmarkSpeed * Globals.NiceHashData[NiceHashID].paying * 0.000000001;
                     }
                     if (SecondaryBenchmarkSpeed > 0 && SecondaryNiceHashID != AlgorithmType.NONE) {

--- a/NiceHashMiner/Algorithm.cs
+++ b/NiceHashMiner/Algorithm.cs
@@ -55,7 +55,7 @@ namespace NiceHashMiner {
             this.AlgorithmName = AlgorithmNiceHashNames.GetName(niceHashID);
             this.SecondaryAlgorithmName = AlgorithmNiceHashNames.GetName(secondaryNiceHashID);
             this.MinerBaseTypeName = Enum.GetName(typeof(MinerBaseType), minerBaseType);
-            this.AlgorithmStringID = this.MinerBaseTypeName + "_" + this.AlgorithmName + "/" + this.SecondaryAlgorithmName;
+            this.AlgorithmStringID = this.MinerBaseTypeName + "_" + this.AlgorithmName + "_" + this.SecondaryAlgorithmName;
 
             MinerBaseType = minerBaseType;
             NiceHashID = niceHashID;

--- a/NiceHashMiner/Algorithm.cs
+++ b/NiceHashMiner/Algorithm.cs
@@ -135,7 +135,7 @@ namespace NiceHashMiner {
                 return BenchmarkStatus;
             } else if (BenchmarkSpeed > 0) {
                 var speedString = Helpers.FormatSpeedOutput(BenchmarkSpeed);
-                if (SecondaryBenchmarkSpeed > 0)  {
+                if (SecondaryNiceHashID != AlgorithmType.NONE)  {
                     speedString += "/" + Helpers.FormatSpeedOutput(SecondaryBenchmarkSpeed);
                 }
                 return speedString;
@@ -143,6 +143,15 @@ namespace NiceHashMiner {
                 return BenchmarkStatus;
             }
             return International.GetText("BenchmarkSpeedStringNone");
+        }
+
+        // convenience for formatting name text
+        public string FormattedSecondaryName() {
+            if (SecondaryAlgorithmName != null)
+            {
+                return "/" + SecondaryAlgorithmName;
+            }
+            return "";
         }
     }
 }

--- a/NiceHashMiner/Algorithm.cs
+++ b/NiceHashMiner/Algorithm.cs
@@ -32,27 +32,8 @@ namespace NiceHashMiner {
         public double CurrentProfit = 0;
         public double CurNhmSMADataVal = 0;
         public double SecondaryCurNhmSMADataVal = 0;
-
-        public Algorithm(MinerBaseType minerBaseType, AlgorithmType niceHashID, string minerName) {
-            this.AlgorithmName = AlgorithmNiceHashNames.GetName(niceHashID);
-            this.MinerBaseTypeName = Enum.GetName(typeof(MinerBaseType), minerBaseType);
-            this.AlgorithmStringID = this.MinerBaseTypeName + "_" + this.AlgorithmName;
-
-            MinerBaseType = minerBaseType;
-            NiceHashID = niceHashID;
-            SecondaryNiceHashID = AlgorithmType.NONE;
-            MinerName = minerName;
-
-            BenchmarkSpeed = 0.0d;
-            SecondaryBenchmarkSpeed = 0.0d;
-            ExtraLaunchParameters = "";
-            LessThreads = 0;
-            Enabled = true;
-            BenchmarkStatus = "";
-        }
-
-        // for ClaymoreDual algos
-        public Algorithm(MinerBaseType minerBaseType, AlgorithmType niceHashID, AlgorithmType secondaryNiceHashID, string minerName) {
+        
+        public Algorithm(MinerBaseType minerBaseType, AlgorithmType niceHashID, string minerName, AlgorithmType secondaryNiceHashID=AlgorithmType.NONE) {
             NiceHashID = niceHashID;
             SecondaryNiceHashID = secondaryNiceHashID;
 
@@ -64,10 +45,10 @@ namespace NiceHashMiner {
             MinerName = minerName;
 
             BenchmarkSpeed = 0.0d;
-            SecondaryBenchmarkSpeed = 1.0d;
+            SecondaryBenchmarkSpeed = 0.0d;
             ExtraLaunchParameters = "";
             LessThreads = 0;
-            Enabled = false;
+            Enabled = !IsDual();
             BenchmarkStatus = "";
         }
 
@@ -91,11 +72,10 @@ namespace NiceHashMiner {
                 string rate = International.GetText("BenchmarkRatioRateN_A");
                 var payingRate = 0.0d;
                 if (Globals.NiceHashData != null) {
-                    if (BenchmarkSpeed > 0)
-                    {
+                    if (BenchmarkSpeed > 0) {
                         payingRate += BenchmarkSpeed * Globals.NiceHashData[NiceHashID].paying * 0.000000001;
                     }
-                    if (SecondaryBenchmarkSpeed > 0 && SecondaryNiceHashID != AlgorithmType.NONE) {
+                    if (SecondaryBenchmarkSpeed > 0 && IsDual()) {
                         payingRate += SecondaryBenchmarkSpeed * Globals.NiceHashData[SecondaryNiceHashID].paying * 0.000000001;
                     }
                     rate = payingRate.ToString("F8");
@@ -156,8 +136,7 @@ namespace NiceHashMiner {
             }
             return NiceHashID;
         }
-        public bool IsDual()
-        {
+        public bool IsDual() {
             return (DualNiceHashID() == AlgorithmType.DaggerDecred ||
                     DualNiceHashID() == AlgorithmType.DaggerLbry ||
                     DualNiceHashID() == AlgorithmType.DaggerPascal);

--- a/NiceHashMiner/Configs/Data/AlgorithmConfig.cs
+++ b/NiceHashMiner/Configs/Data/AlgorithmConfig.cs
@@ -8,9 +8,11 @@ namespace NiceHashMiner.Configs.Data {
     public class AlgorithmConfig {
         public string Name = ""; // Used as an indicator for easier user interaction
         public AlgorithmType NiceHashID = AlgorithmType.NONE;
+        public AlgorithmType SecondaryNiceHashID = AlgorithmType.NONE;
         public MinerBaseType MinerBaseType = MinerBaseType.NONE;
         public string MinerName = "";  // probably not needed
         public double BenchmarkSpeed = 0;
+        public double SecondaryBenchmarkSpeed = 0;
         public string ExtraLaunchParameters= "";
         public bool Enabled = true;
         public int LessThreads = 0;

--- a/NiceHashMiner/Devices/ComputeDevice.cs
+++ b/NiceHashMiner/Devices/ComputeDevice.cs
@@ -127,8 +127,8 @@ namespace NiceHashMiner.Devices
             return String.Format(International.GetText("ComputeDevice_Full_Device_Name"), NameCount, Name);
         }
 
-        public Algorithm GetAlgorithm(MinerBaseType MinerBaseType, AlgorithmType AlgorithmType) {
-            int toSetIndex = this.AlgorithmSettings.FindIndex((a) => a.NiceHashID == AlgorithmType && a.MinerBaseType == MinerBaseType);
+        public Algorithm GetAlgorithm(MinerBaseType MinerBaseType, AlgorithmType AlgorithmType, AlgorithmType SecondaryAlgorithmType) {
+            int toSetIndex = this.AlgorithmSettings.FindIndex((a) => a.NiceHashID == AlgorithmType && a.MinerBaseType == MinerBaseType && a.SecondaryNiceHashID == SecondaryAlgorithmType);
             if (toSetIndex > -1) {
                 return this.AlgorithmSettings[toSetIndex];
             }
@@ -145,9 +145,10 @@ namespace NiceHashMiner.Devices
 
         public void CopyBenchmarkSettingsFrom(ComputeDevice copyBenchCDev) {
             foreach (var copyFromAlgo in copyBenchCDev.AlgorithmSettings) {
-                var setAlgo = GetAlgorithm(copyFromAlgo.MinerBaseType, copyFromAlgo.NiceHashID);
+                var setAlgo = GetAlgorithm(copyFromAlgo.MinerBaseType, copyFromAlgo.NiceHashID, copyFromAlgo.SecondaryNiceHashID);
                 if (setAlgo != null) {
                     setAlgo.BenchmarkSpeed = copyFromAlgo.BenchmarkSpeed;
+                    setAlgo.SecondaryBenchmarkSpeed = copyFromAlgo.SecondaryBenchmarkSpeed;
                     setAlgo.ExtraLaunchParameters = copyFromAlgo.ExtraLaunchParameters;
                     setAlgo.LessThreads = copyFromAlgo.LessThreads;
                 }
@@ -166,9 +167,10 @@ namespace NiceHashMiner.Devices
             if (config != null && config.DeviceUUID == UUID && config.AlgorithmSettings != null) {
                 this.AlgorithmSettings = GroupAlgorithms.CreateForDeviceList(this);
                 foreach (var conf in config.AlgorithmSettings) {
-                    var setAlgo = GetAlgorithm(conf.MinerBaseType, conf.NiceHashID);
+                    var setAlgo = GetAlgorithm(conf.MinerBaseType, conf.NiceHashID, conf.SecondaryNiceHashID);
                     if (setAlgo != null) {
                         setAlgo.BenchmarkSpeed = conf.BenchmarkSpeed;
+                        setAlgo.SecondaryBenchmarkSpeed = conf.SecondaryBenchmarkSpeed;
                         setAlgo.ExtraLaunchParameters = conf.ExtraLaunchParameters;
                         setAlgo.Enabled = conf.Enabled;
                         setAlgo.LessThreads = conf.LessThreads;
@@ -194,9 +196,11 @@ namespace NiceHashMiner.Devices
                 AlgorithmConfig conf = new AlgorithmConfig();
                 conf.Name = algo.AlgorithmStringID;
                 conf.NiceHashID = algo.NiceHashID;
+                conf.SecondaryNiceHashID = algo.SecondaryNiceHashID;
                 conf.MinerBaseType = algo.MinerBaseType;
                 conf.MinerName = algo.MinerName; // TODO probably not needed
                 conf.BenchmarkSpeed = algo.BenchmarkSpeed;
+                conf.SecondaryBenchmarkSpeed = algo.SecondaryBenchmarkSpeed;
                 conf.ExtraLaunchParameters = algo.ExtraLaunchParameters;
                 conf.Enabled = algo.Enabled;
                 conf.LessThreads = algo.LessThreads;

--- a/NiceHashMiner/Devices/GroupAlgorithms.cs
+++ b/NiceHashMiner/Devices/GroupAlgorithms.cs
@@ -188,7 +188,10 @@ namespace NiceHashMiner.Devices {
                         new List<Algorithm>() {
                             new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.CryptoNight, "cryptonight"),
                             new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.Equihash, "equihash"),
-                            new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.DaggerHashimoto, "")
+                            new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.DaggerHashimoto, ""),
+                            new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.DaggerHashimoto, AlgorithmType.Decred, ""),
+                            new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.DaggerHashimoto, AlgorithmType.Lbry, ""),
+                            new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.DaggerHashimoto, AlgorithmType.Pascal, "")
                         }
                     },
                     { MinerBaseType.OptiminerAMD,

--- a/NiceHashMiner/Devices/GroupAlgorithms.cs
+++ b/NiceHashMiner/Devices/GroupAlgorithms.cs
@@ -189,9 +189,9 @@ namespace NiceHashMiner.Devices {
                             new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.CryptoNight, "cryptonight"),
                             new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.Equihash, "equihash"),
                             new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.DaggerHashimoto, ""),
-                            new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.DaggerHashimoto, AlgorithmType.Decred, ""),
-                            new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.DaggerHashimoto, AlgorithmType.Lbry, ""),
-                            new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.DaggerHashimoto, AlgorithmType.Pascal, "")
+                            new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.DaggerHashimoto, "", AlgorithmType.Decred),
+                            new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.DaggerHashimoto, "", AlgorithmType.Lbry),
+                            new Algorithm(MinerBaseType.ClaymoreAMD, AlgorithmType.DaggerHashimoto, "", AlgorithmType.Pascal)
                         }
                     },
                     { MinerBaseType.OptiminerAMD,

--- a/NiceHashMiner/Enums/AlgorithmType.cs
+++ b/NiceHashMiner/Enums/AlgorithmType.cs
@@ -10,6 +10,10 @@ namespace NiceHashMiner.Enums
     /// </summary>
     public enum AlgorithmType : int
     {
+        // dual algos for grouping
+        DaggerDecred = -5,
+        DaggerLbry = -4,
+        DaggerPascal = -3,
         INVALID = -2,
         NONE = -1,
         #region NiceHashAPI

--- a/NiceHashMiner/Forms/Components/AlgorithmSettingsControl.Designer.cs
+++ b/NiceHashMiner/Forms/Components/AlgorithmSettingsControl.Designer.cs
@@ -27,6 +27,7 @@
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.field_LessThreads = new NiceHashMiner.Forms.Components.Field();
             this.fieldBoxBenchmarkSpeed = new NiceHashMiner.Forms.Components.Field();
+            this.secondaryFieldBoxBenchmarkSpeed = new NiceHashMiner.Forms.Components.Field();
             this.groupBoxExtraLaunchParameters = new System.Windows.Forms.GroupBox();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
             this.richTextBoxExtraLaunchParameters = new System.Windows.Forms.RichTextBox();
@@ -50,6 +51,7 @@
             // 
             this.flowLayoutPanel1.Controls.Add(this.field_LessThreads);
             this.flowLayoutPanel1.Controls.Add(this.fieldBoxBenchmarkSpeed);
+            this.flowLayoutPanel1.Controls.Add(this.secondaryFieldBoxBenchmarkSpeed);
             this.flowLayoutPanel1.Controls.Add(this.groupBoxExtraLaunchParameters);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
@@ -80,13 +82,24 @@
             this.fieldBoxBenchmarkSpeed.Size = new System.Drawing.Size(220, 47);
             this.fieldBoxBenchmarkSpeed.TabIndex = 1;
             // 
+            // secondaryFieldBoxBenchmarkSpeed
+            // 
+            this.secondaryFieldBoxBenchmarkSpeed.AutoSize = true;
+            this.secondaryFieldBoxBenchmarkSpeed.BackColor = System.Drawing.Color.Transparent;
+            this.secondaryFieldBoxBenchmarkSpeed.EntryText = "";
+            this.secondaryFieldBoxBenchmarkSpeed.LabelText = "Secondary Benchmark Speed (H/s):";
+            this.secondaryFieldBoxBenchmarkSpeed.Location = new System.Drawing.Point(3, 109);
+            this.secondaryFieldBoxBenchmarkSpeed.Name = "secondaryFieldBoxBenchmarkSpeed";
+            this.secondaryFieldBoxBenchmarkSpeed.Size = new System.Drawing.Size(220, 47);
+            this.secondaryFieldBoxBenchmarkSpeed.TabIndex = 16;
+            // 
             // groupBoxExtraLaunchParameters
             // 
             this.groupBoxExtraLaunchParameters.Controls.Add(this.pictureBox1);
             this.groupBoxExtraLaunchParameters.Controls.Add(this.richTextBoxExtraLaunchParameters);
-            this.groupBoxExtraLaunchParameters.Location = new System.Drawing.Point(3, 109);
+            this.groupBoxExtraLaunchParameters.Location = new System.Drawing.Point(3, 162);
             this.groupBoxExtraLaunchParameters.Name = "groupBoxExtraLaunchParameters";
-            this.groupBoxExtraLaunchParameters.Size = new System.Drawing.Size(217, 101);
+            this.groupBoxExtraLaunchParameters.Size = new System.Drawing.Size(217, 95);
             this.groupBoxExtraLaunchParameters.TabIndex = 14;
             this.groupBoxExtraLaunchParameters.TabStop = false;
             this.groupBoxExtraLaunchParameters.Text = "Extra Launch Parameters:";
@@ -134,6 +147,7 @@
         private System.Windows.Forms.RichTextBox richTextBoxExtraLaunchParameters;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
         private Field fieldBoxBenchmarkSpeed;
+        private Field secondaryFieldBoxBenchmarkSpeed;
         private Field field_LessThreads;
         private System.Windows.Forms.PictureBox pictureBox1;
     }

--- a/NiceHashMiner/Forms/Components/AlgorithmSettingsControl.cs
+++ b/NiceHashMiner/Forms/Components/AlgorithmSettingsControl.cs
@@ -78,7 +78,7 @@ namespace NiceHashMiner.Forms.Components {
                 this.Enabled = lvi.Checked;
                 
                 groupBoxSelectedAlgorithmSettings.Text = String.Format(International.GetText("AlgorithmsListView_GroupBox"),
-                String.Format("{0} ({1})", algorithm.AlgorithmName + algorithm.FormattedSecondaryName(), algorithm.MinerBaseTypeName)); ;
+                String.Format("{0} ({1})", algorithm.AlgorithmName, algorithm.MinerBaseTypeName)); ;
 
                 field_LessThreads.Enabled = _computeDevice.DeviceGroupType == DeviceGroupType.CPU;
                 if (field_LessThreads.Enabled) {
@@ -138,11 +138,7 @@ namespace NiceHashMiner.Forms.Components {
 
         private void updateSpeedText()
         {
-            var speedString = Helpers.FormatSpeedOutput(_currentlySelectedAlgorithm.BenchmarkSpeed);
-            if (_currentlySelectedAlgorithm.SecondaryNiceHashID != AlgorithmType.NONE)
-            {
-                speedString += "/" + Helpers.FormatSpeedOutput(_currentlySelectedAlgorithm.SecondaryBenchmarkSpeed);
-            }
+            var speedString = Helpers.FormatDualSpeedOutput(_currentlySelectedAlgorithm.BenchmarkSpeed, _currentlySelectedAlgorithm.SecondaryBenchmarkSpeed);
             // update lvi speed
             if (_currentlySelectedLvi != null)
             {

--- a/NiceHashMiner/Forms/Components/AlgorithmSettingsControl.cs
+++ b/NiceHashMiner/Forms/Components/AlgorithmSettingsControl.cs
@@ -76,7 +76,7 @@ namespace NiceHashMiner.Forms.Components {
                 _currentlySelectedAlgorithm = algorithm;
                 _currentlySelectedLvi = lvi;
                 this.Enabled = lvi.Checked;
-                
+
                 groupBoxSelectedAlgorithmSettings.Text = String.Format(International.GetText("AlgorithmsListView_GroupBox"),
                 String.Format("{0} ({1})", algorithm.AlgorithmName, algorithm.MinerBaseTypeName)); ;
 
@@ -129,8 +129,7 @@ namespace NiceHashMiner.Forms.Components {
         private void secondaryTextChangedBenchmarkSpeed(object sender, EventArgs e)
         {
             double secondaryValue;
-            if (Double.TryParse(secondaryFieldBoxBenchmarkSpeed.EntryText, out secondaryValue))
-            {
+            if (Double.TryParse(secondaryFieldBoxBenchmarkSpeed.EntryText, out secondaryValue)) {
                 _currentlySelectedAlgorithm.SecondaryBenchmarkSpeed = secondaryValue;
             }
             updateSpeedText();
@@ -140,8 +139,7 @@ namespace NiceHashMiner.Forms.Components {
         {
             var speedString = Helpers.FormatDualSpeedOutput(_currentlySelectedAlgorithm.BenchmarkSpeed, _currentlySelectedAlgorithm.SecondaryBenchmarkSpeed);
             // update lvi speed
-            if (_currentlySelectedLvi != null)
-            {
+            if (_currentlySelectedLvi != null) {
                 _currentlySelectedLvi.SubItems[2].Text = speedString;
             }
         }

--- a/NiceHashMiner/Forms/Components/AlgorithmSettingsControl.cs
+++ b/NiceHashMiner/Forms/Components/AlgorithmSettingsControl.cs
@@ -21,10 +21,12 @@ namespace NiceHashMiner.Forms.Components {
         public AlgorithmSettingsControl() {
             InitializeComponent();
             fieldBoxBenchmarkSpeed.SetInputModeDoubleOnly();
+            secondaryFieldBoxBenchmarkSpeed.SetInputModeDoubleOnly();
             field_LessThreads.SetInputModeIntOnly();
 
             field_LessThreads.SetOnTextLeave(LessThreads_Leave);
             fieldBoxBenchmarkSpeed.SetOnTextChanged(textChangedBenchmarkSpeed);
+            secondaryFieldBoxBenchmarkSpeed.SetOnTextChanged(secondaryTextChangedBenchmarkSpeed);
             richTextBoxExtraLaunchParameters.TextChanged += textChangedExtraLaunchParameters;
 
         }
@@ -35,6 +37,7 @@ namespace NiceHashMiner.Forms.Components {
                 International.GetText("AlgorithmsListView_GroupBox_NONE"));
             Enabled = false;
             fieldBoxBenchmarkSpeed.EntryText = "";
+            secondaryFieldBoxBenchmarkSpeed.EntryText = "";
             field_LessThreads.EntryText = "";
             richTextBoxExtraLaunchParameters.Text = "";
         }
@@ -46,6 +49,9 @@ namespace NiceHashMiner.Forms.Components {
             fieldBoxBenchmarkSpeed.InitLocale(toolTip1,
                 International.GetText("Form_Settings_Algo_BenchmarkSpeed") + ":",
                 International.GetText("Form_Settings_ToolTip_AlgoBenchmarkSpeed"));
+            secondaryFieldBoxBenchmarkSpeed.InitLocale(toolTip1,
+                International.GetText("Form_Settings_Algo_SecondaryBenchmarkSpeed") + ":",
+                International.GetText("Form_Settings_ToolTip_AlgoSecondaryBenchmarkSpeed"));
             groupBoxExtraLaunchParameters.Text = International.GetText("Form_Settings_General_ExtraLaunchParameters");
             toolTip1.SetToolTip(groupBoxExtraLaunchParameters, International.GetText("Form_Settings_ToolTip_AlgoExtraLaunchParameters"));
             toolTip1.SetToolTip(pictureBox1, International.GetText("Form_Settings_ToolTip_AlgoExtraLaunchParameters"));
@@ -70,9 +76,9 @@ namespace NiceHashMiner.Forms.Components {
                 _currentlySelectedAlgorithm = algorithm;
                 _currentlySelectedLvi = lvi;
                 this.Enabled = lvi.Checked;
-
+                
                 groupBoxSelectedAlgorithmSettings.Text = String.Format(International.GetText("AlgorithmsListView_GroupBox"),
-                String.Format("{0} ({1})", algorithm.AlgorithmName, algorithm.MinerBaseTypeName)); ;
+                String.Format("{0} ({1})", algorithm.AlgorithmName + algorithm.FormattedSecondaryName(), algorithm.MinerBaseTypeName)); ;
 
                 field_LessThreads.Enabled = _computeDevice.DeviceGroupType == DeviceGroupType.CPU;
                 if (field_LessThreads.Enabled) {
@@ -80,6 +86,8 @@ namespace NiceHashMiner.Forms.Components {
                 }
                 fieldBoxBenchmarkSpeed.EntryText = ParseDoubleDefault(algorithm.BenchmarkSpeed);
                 richTextBoxExtraLaunchParameters.Text = ParseStringDefault(algorithm.ExtraLaunchParameters);
+                secondaryFieldBoxBenchmarkSpeed.EntryText = ParseDoubleDefault(algorithm.SecondaryBenchmarkSpeed);
+                secondaryFieldBoxBenchmarkSpeed.Enabled = _currentlySelectedAlgorithm.SecondaryNiceHashID != AlgorithmType.NONE;
                 this.Update();
             } else {
                 // TODO this should not be null
@@ -99,6 +107,7 @@ namespace NiceHashMiner.Forms.Components {
                 var algorithm = lvi.Tag as Algorithm;
                 if (algorithm != null) {
                     fieldBoxBenchmarkSpeed.EntryText = ParseDoubleDefault(algorithm.BenchmarkSpeed);
+                    secondaryFieldBoxBenchmarkSpeed.EntryText = ParseDoubleDefault(algorithm.SecondaryBenchmarkSpeed);
                 }
             }
         }
@@ -113,10 +122,31 @@ namespace NiceHashMiner.Forms.Components {
             double value;
             if (Double.TryParse(fieldBoxBenchmarkSpeed.EntryText, out value)) {
                 _currentlySelectedAlgorithm.BenchmarkSpeed = value;
-                // update lvi speed
-                if (_currentlySelectedLvi != null) {
-                    _currentlySelectedLvi.SubItems[2].Text = Helpers.FormatSpeedOutput(value);
-                }
+            }
+            updateSpeedText();
+        }
+
+        private void secondaryTextChangedBenchmarkSpeed(object sender, EventArgs e)
+        {
+            double secondaryValue;
+            if (Double.TryParse(secondaryFieldBoxBenchmarkSpeed.EntryText, out secondaryValue))
+            {
+                _currentlySelectedAlgorithm.SecondaryBenchmarkSpeed = secondaryValue;
+            }
+            updateSpeedText();
+        }
+
+        private void updateSpeedText()
+        {
+            var speedString = Helpers.FormatSpeedOutput(_currentlySelectedAlgorithm.BenchmarkSpeed);
+            if (_currentlySelectedAlgorithm.SecondaryNiceHashID != AlgorithmType.NONE)
+            {
+                speedString += "/" + Helpers.FormatSpeedOutput(_currentlySelectedAlgorithm.SecondaryBenchmarkSpeed);
+            }
+            // update lvi speed
+            if (_currentlySelectedLvi != null)
+            {
+                _currentlySelectedLvi.SubItems[2].Text = speedString;
             }
         }
 

--- a/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
+++ b/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
@@ -91,12 +91,7 @@ namespace NiceHashMiner.Forms.Components {
             listViewAlgorithms.Items.Clear();
             foreach (var alg in computeDevice.GetAlgorithmSettings()) {
                 ListViewItem lvi = new ListViewItem();
-                if (alg.SecondaryAlgorithmName != null) {
-                    ListViewItem.ListViewSubItem sub = lvi.SubItems.Add(String.Format("{0}/{1} ({2})", alg.AlgorithmName, alg.SecondaryAlgorithmName, alg.MinerBaseTypeName));
-                }
-                else {
-                    ListViewItem.ListViewSubItem sub = lvi.SubItems.Add(String.Format("{0} ({1})", alg.AlgorithmName, alg.MinerBaseTypeName));
-                }
+                ListViewItem.ListViewSubItem sub = lvi.SubItems.Add(String.Format("{0} ({1})", alg.AlgorithmName + alg.FormattedSecondaryName(), alg.MinerBaseTypeName));
 
                 //sub.Tag = alg.Value;
                 lvi.SubItems.Add(alg.BenchmarkSpeedString());

--- a/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
+++ b/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
@@ -91,7 +91,12 @@ namespace NiceHashMiner.Forms.Components {
             listViewAlgorithms.Items.Clear();
             foreach (var alg in computeDevice.GetAlgorithmSettings()) {
                 ListViewItem lvi = new ListViewItem();
-                ListViewItem.ListViewSubItem sub = lvi.SubItems.Add(String.Format("{0} ({1})", alg.AlgorithmName, alg.MinerBaseTypeName));
+                if (alg.SecondaryAlgorithmName != null) {
+                    ListViewItem.ListViewSubItem sub = lvi.SubItems.Add(String.Format("{0}/{1} ({2})", alg.AlgorithmName, alg.SecondaryAlgorithmName, alg.MinerBaseTypeName));
+                }
+                else {
+                    ListViewItem.ListViewSubItem sub = lvi.SubItems.Add(String.Format("{0} ({1})", alg.AlgorithmName, alg.MinerBaseTypeName));
+                }
 
                 //sub.Tag = alg.Value;
                 lvi.SubItems.Add(alg.BenchmarkSpeedString());

--- a/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
+++ b/NiceHashMiner/Forms/Components/AlgorithmsListView.cs
@@ -91,7 +91,7 @@ namespace NiceHashMiner.Forms.Components {
             listViewAlgorithms.Items.Clear();
             foreach (var alg in computeDevice.GetAlgorithmSettings()) {
                 ListViewItem lvi = new ListViewItem();
-                ListViewItem.ListViewSubItem sub = lvi.SubItems.Add(String.Format("{0} ({1})", alg.AlgorithmName + alg.FormattedSecondaryName(), alg.MinerBaseTypeName));
+                ListViewItem.ListViewSubItem sub = lvi.SubItems.Add(String.Format("{0} ({1})", alg.AlgorithmName, alg.MinerBaseTypeName));
 
                 //sub.Tag = alg.Value;
                 lvi.SubItems.Add(alg.BenchmarkSpeedString());

--- a/NiceHashMiner/Forms/Form_Main.cs
+++ b/NiceHashMiner/Forms/Form_Main.cs
@@ -487,7 +487,7 @@ namespace NiceHashMiner
         public void AddRateInfo(string groupName, string deviceStringInfo, APIData iAPIData, double paying, bool isApiGetException) {
             string ApiGetExceptionString = isApiGetException ? "**" : "";
 
-            string speedString = Helpers.FormatSpeedOutput(iAPIData.Speed) + iAPIData.AlgorithmName + ApiGetExceptionString;
+            string speedString = Helpers.FormatDualSpeedOutput(iAPIData.Speed) + iAPIData.AlgorithmName + ApiGetExceptionString;
             if (iAPIData.AlgorithmID == AlgorithmType.Equihash) {
                 speedString = speedString.Replace("H/s", "Sols/s");
             }

--- a/NiceHashMiner/Forms/Form_Main.cs
+++ b/NiceHashMiner/Forms/Form_Main.cs
@@ -487,7 +487,7 @@ namespace NiceHashMiner
         public void AddRateInfo(string groupName, string deviceStringInfo, APIData iAPIData, double paying, bool isApiGetException) {
             string ApiGetExceptionString = isApiGetException ? "**" : "";
 
-            string speedString = Helpers.FormatDualSpeedOutput(iAPIData.Speed) + iAPIData.AlgorithmName + ApiGetExceptionString;
+            string speedString = Helpers.FormatDualSpeedOutput(iAPIData.Speed, iAPIData.SecondarySpeed) + iAPIData.AlgorithmName + ApiGetExceptionString;
             if (iAPIData.AlgorithmID == AlgorithmType.Equihash) {
                 speedString = speedString.Replace("H/s", "Sols/s");
             }

--- a/NiceHashMiner/Forms/Form_Settings.cs
+++ b/NiceHashMiner/Forms/Form_Settings.cs
@@ -525,7 +525,7 @@ namespace NiceHashMiner.Forms {
                     if (cDev.DeviceType == DeviceType.CPU) continue; // cpu has no defaults
                     var deviceDefaultsAlgoSettings = GroupAlgorithms.CreateForDeviceList(cDev);
                     foreach (var defaultAlgoSettings in deviceDefaultsAlgoSettings) {
-                        var toSetAlgo = cDev.GetAlgorithm(defaultAlgoSettings.MinerBaseType, defaultAlgoSettings.NiceHashID);
+                        var toSetAlgo = cDev.GetAlgorithm(defaultAlgoSettings.MinerBaseType, defaultAlgoSettings.NiceHashID, defaultAlgoSettings.SecondaryNiceHashID);
                         if (toSetAlgo != null) {
                             toSetAlgo.ExtraLaunchParameters = defaultAlgoSettings.ExtraLaunchParameters;
                             toSetAlgo.ExtraLaunchParameters = ExtraLaunchParametersParser.ParseForMiningPair(

--- a/NiceHashMiner/Miners/ClaymoreBaseMiner.cs
+++ b/NiceHashMiner/Miners/ClaymoreBaseMiner.cs
@@ -25,6 +25,7 @@ namespace NiceHashMiner.Miners {
         // only dagger change
         protected bool ignoreZero = false;
         protected double api_read_mult = 1;
+        protected AlgorithmType SecondaryAlgorithmType = AlgorithmType.NONE;
 
         public ClaymoreBaseMiner(string minerDeviceName, string look_FOR_START)
             : base(minerDeviceName) {

--- a/NiceHashMiner/Miners/ClaymoreBaseMiner.cs
+++ b/NiceHashMiner/Miners/ClaymoreBaseMiner.cs
@@ -38,9 +38,13 @@ namespace NiceHashMiner.Miners {
 
         protected abstract double DevFee();
 
-        protected virtual string SecondaryLookForStart()
-        {
+        protected virtual string SecondaryLookForStart() {
             return "";
+        }
+
+        // return true if a secondary algo is being used
+        public bool IsDual() {
+            return (SecondaryAlgorithmType != AlgorithmType.NONE);
         }
 
         protected override int GET_MAX_CooldownTimeInMilliseconds() {

--- a/NiceHashMiner/Miners/ClaymoreBaseMiner.cs
+++ b/NiceHashMiner/Miners/ClaymoreBaseMiner.cs
@@ -61,7 +61,7 @@ namespace NiceHashMiner.Miners {
 
         public override APIData GetSummary() {
             _currentMinerReadStatus = MinerAPIReadStatus.NONE;
-            APIData ad = new APIData(MiningSetup.CurrentAlgorithmType);
+            APIData ad = new APIData(MiningSetup.CurrentAlgorithmType, MiningSetup.CurrentSecondaryAlgorithmType);
 
             TcpClient client = null;
             JsonApiResponse resp = null;
@@ -85,7 +85,9 @@ namespace NiceHashMiner.Miners {
                 if (resp.result != null && resp.result.Count > 4) {
                     //Helpers.ConsolePrint("ClaymoreZcashMiner API back:", "resp.result != null && resp.result.Count > 4");
                     var speeds = resp.result[3].Split(';');
+                    var secondarySpeeds = resp.result[5].Split(';');
                     ad.Speed = 0;
+                    ad.SecondarySpeed = 0;
                     foreach (var speed in speeds) {
                         //Helpers.ConsolePrint("ClaymoreZcashMiner API back:", "foreach (var speed in speeds) {");
                         double tmpSpeed = 0;
@@ -96,7 +98,17 @@ namespace NiceHashMiner.Miners {
                         }
                         ad.Speed += tmpSpeed;
                     }
+                    foreach (var speed in secondarySpeeds) {
+                        double tmpSpeed = 0;
+                        try {
+                            tmpSpeed = Double.Parse(speed, CultureInfo.InvariantCulture);
+                        } catch {
+                            tmpSpeed = 0;
+                        }
+                        ad.SecondarySpeed += tmpSpeed;
+                    }
                     ad.Speed *= api_read_mult;
+                    ad.SecondarySpeed *= api_read_mult;
                     _currentMinerReadStatus = MinerAPIReadStatus.GOT_READ;
                 }
                 if (ad.Speed == 0) {

--- a/NiceHashMiner/Miners/ClaymoreBaseMiner.cs
+++ b/NiceHashMiner/Miners/ClaymoreBaseMiner.cs
@@ -19,6 +19,8 @@ namespace NiceHashMiner.Miners {
         protected int benchmarkTimeWait = 2 * 45; // Ok... this was all wrong 
         int benchmark_read_count = 0;
         double benchmark_sum = 0.0d;
+        int secondary_benchmark_read_count = 0;
+        double secondary_benchmark_sum = 0.0d;
         protected readonly string LOOK_FOR_START;
         const string LOOK_FOR_END = "h/s";
 
@@ -35,6 +37,11 @@ namespace NiceHashMiner.Miners {
         }
 
         protected abstract double DevFee();
+
+        protected virtual string SecondaryLookForStart()
+        {
+            return "";
+        }
 
         protected override int GET_MAX_CooldownTimeInMilliseconds() {
             return 60 * 1000 * 5; // 5 minute max, whole waiting time 75seconds
@@ -220,10 +227,23 @@ namespace NiceHashMiner.Miners {
                                     ++benchmark_read_count;
                                 }
                             }
+                            else if (lineLowered.Contains(SecondaryLookForStart())) {
+                                if (ignoreZero) {
+                                    double got = getNumber(lineLowered, SecondaryLookForStart(), LOOK_FOR_END);
+                                    if (got != 0) {
+                                        secondary_benchmark_sum += got;
+                                        ++secondary_benchmark_read_count;
+                                    }
+                                } else {
+                                    secondary_benchmark_sum += getNumber(lineLowered);
+                                    ++secondary_benchmark_read_count;
+                                }
+                            }
                         }
                     }
                     if (benchmark_read_count > 0) {
                         BenchmarkAlgorithm.BenchmarkSpeed = benchmark_sum / benchmark_read_count;
+                        BenchmarkAlgorithm.SecondaryBenchmarkSpeed = secondary_benchmark_sum / secondary_benchmark_read_count;
                     }
                 }
                 BenchmarkThreadRoutineFinish();

--- a/NiceHashMiner/Miners/ClaymoreDual.cs
+++ b/NiceHashMiner/Miners/ClaymoreDual.cs
@@ -22,6 +22,23 @@ namespace NiceHashMiner.Miners {
             return (SecondaryAlgorithmType == AlgorithmType.NONE) ? 1.0 : 2.0;
         }
 
+        // the short form the miner uses for secondary algos
+        public string SecondaryShortName() {
+            switch (SecondaryAlgorithmType) {
+                case AlgorithmType.Decred:
+                    return "dcr";
+                case AlgorithmType.Lbry:
+                    return "lbc";
+                case AlgorithmType.Pascal:
+                    return "pasc";
+            }
+            return "";
+        }
+
+        protected override string SecondaryLookForStart() {
+            return (SecondaryShortName() + " - Total Speed:").ToLower();
+        }
+
         protected override int GET_MAX_CooldownTimeInMilliseconds() {
             return 90 * 1000; // 1.5 minute max, whole waiting time 75seconds
         }
@@ -30,15 +47,18 @@ namespace NiceHashMiner.Miners {
             string username = GetUsername(btcAdress, worker);
 
             string dualModeParams = "";
-            AlgorithmType dual = SecondaryAlgorithmType;
-            if (dual == AlgorithmType.NONE) {  // leave convenience param for non-dual entry
+            if (SecondaryAlgorithmType == AlgorithmType.NONE)
+            {  // leave convenience param for non-dual entry
                 foreach (var pair in MiningSetup.MiningPairs)
                 {
                     if (pair.CurrentExtraLaunchParameters.Contains("-dual="))
                     {
+                        AlgorithmType dual = AlgorithmType.NONE;
+                        string coinP = "";
                         if (pair.CurrentExtraLaunchParameters.Contains("Decred"))
                         {
                             dual = AlgorithmType.Decred;
+                            coinP = " -dcoin dcr ";
                         }
                         //if (pair.CurrentExtraLaunchParameters.Contains("Siacoin")) {
                         //    dual = AlgorithmType.;
@@ -46,33 +66,26 @@ namespace NiceHashMiner.Miners {
                         if (pair.CurrentExtraLaunchParameters.Contains("Lbry"))
                         {
                             dual = AlgorithmType.Lbry;
+                            coinP = " -dcoin lbc ";
                         }
                         if (pair.CurrentExtraLaunchParameters.Contains("Pascal"))
                         {
                             dual = AlgorithmType.Pascal;
+                            coinP = " -dcoin pasc ";
                         }
                         if (dual != AlgorithmType.NONE)
                         {
+                            string urlSecond = Globals.GetLocationURL(dual, Globals.MiningLocation[ConfigManager.GeneralConfig.ServiceLocation], this.ConectionType);
+                            dualModeParams = String.Format(" {0} -dpool {1} -dwal {2}", coinP, urlSecond, username);
                             break;
                         }
                     }
                 }
             }
-
-            if (dual != AlgorithmType.NONE)
+            else
             {
-                string coinP = "";
-                if (dual == AlgorithmType.Decred) {
-                    coinP = " -dcoin dcr ";
-                }
-                else if (dual == AlgorithmType.Lbry) {
-                    coinP = " -dcoin lbc ";
-                }
-                else if (dual == AlgorithmType.Pascal) {
-                    coinP = " -dcoin pasc ";
-                }
-                string urlSecond = Globals.GetLocationURL(dual, Globals.MiningLocation[ConfigManager.GeneralConfig.ServiceLocation], this.ConectionType);
-                dualModeParams = String.Format(" {0} -dpool {1} -dwal {2}", coinP, urlSecond, username);
+                string urlSecond = Globals.GetLocationURL(SecondaryAlgorithmType, Globals.MiningLocation[ConfigManager.GeneralConfig.ServiceLocation], this.ConectionType);
+                dualModeParams = String.Format(" -dcoin {0} -dpool {1} -dwal {2}", SecondaryShortName(), urlSecond, username);
             }
 
             return " "
@@ -99,8 +112,8 @@ namespace NiceHashMiner.Miners {
             string url = Globals.GetLocationURL(algorithm.NiceHashID, Globals.MiningLocation[ConfigManager.GeneralConfig.ServiceLocation], this.ConectionType);
             // demo for benchmark
             string ret = GetStartCommand(url, Globals.DemoUser, ConfigManager.GeneralConfig.WorkerName.Trim());
-            // local benhcmark
-            return ret + "  -benchmark 1";
+            // local benhcmark (benchmark does not work in dual
+            return ret + ((SecondaryAlgorithmType == AlgorithmType.NONE) ? "  -benchmark 1" : "");
         }
 
     }

--- a/NiceHashMiner/Miners/ClaymoreDual.cs
+++ b/NiceHashMiner/Miners/ClaymoreDual.cs
@@ -8,17 +8,18 @@ namespace NiceHashMiner.Miners {
     public class ClaymoreDual : ClaymoreBaseMiner {
 
         const string _LOOK_FOR_START = "ETH - Total Speed:";
-        public ClaymoreDual()
+        public ClaymoreDual(AlgorithmType secondaryAlgorithmType)
             : base("ClaymoreDual", _LOOK_FOR_START) {
             ignoreZero = true;
             api_read_mult = 1000;
             ConectionType = NHMConectionType.STRATUM_TCP;
+            SecondaryAlgorithmType = secondaryAlgorithmType;
         }
 
         // eth-only: 1%
         // eth-dual-mine: 2%
         protected override double DevFee() {
-            return 1.0;
+            return (SecondaryAlgorithmType == AlgorithmType.NONE) ? 1.0 : 2.0;
         }
 
         protected override int GET_MAX_CooldownTimeInMilliseconds() {
@@ -29,32 +30,51 @@ namespace NiceHashMiner.Miners {
             string username = GetUsername(btcAdress, worker);
 
             string dualModeParams = "";
-            foreach (var pair in MiningSetup.MiningPairs) {
-                if (pair.CurrentExtraLaunchParameters.Contains("-dual=")) {
-                    AlgorithmType dual = AlgorithmType.NONE;
-                    string coinP = "";
-                    if (pair.CurrentExtraLaunchParameters.Contains("Decred")) {
-                        dual = AlgorithmType.Decred;
-                        coinP = " -dcoin dcr ";
-                    }
-                    //if (pair.CurrentExtraLaunchParameters.Contains("Siacoin")) {
-                    //    dual = AlgorithmType.;
-                    //}
-                    if (pair.CurrentExtraLaunchParameters.Contains("Lbry")) {
-                        dual = AlgorithmType.Lbry;
-                        coinP = " -dcoin lbc ";
-                    }
-                    if (pair.CurrentExtraLaunchParameters.Contains("Pascal")) {
-                        dual = AlgorithmType.Pascal;
-                        coinP = " -dcoin pasc ";
-                    }
-                    if (dual != AlgorithmType.NONE) {
-                        string urlSecond = Globals.GetLocationURL(dual, Globals.MiningLocation[ConfigManager.GeneralConfig.ServiceLocation], this.ConectionType);
-                        dualModeParams = String.Format(" {0} -dpool {1} -dwal {2}", coinP, urlSecond, username);
-                        break;
+            AlgorithmType dual = SecondaryAlgorithmType;
+            if (dual == AlgorithmType.NONE) {  // leave convenience param for non-dual entry
+                foreach (var pair in MiningSetup.MiningPairs)
+                {
+                    if (pair.CurrentExtraLaunchParameters.Contains("-dual="))
+                    {
+                        if (pair.CurrentExtraLaunchParameters.Contains("Decred"))
+                        {
+                            dual = AlgorithmType.Decred;
+                        }
+                        //if (pair.CurrentExtraLaunchParameters.Contains("Siacoin")) {
+                        //    dual = AlgorithmType.;
+                        //}
+                        if (pair.CurrentExtraLaunchParameters.Contains("Lbry"))
+                        {
+                            dual = AlgorithmType.Lbry;
+                        }
+                        if (pair.CurrentExtraLaunchParameters.Contains("Pascal"))
+                        {
+                            dual = AlgorithmType.Pascal;
+                        }
+                        if (dual != AlgorithmType.NONE)
+                        {
+                            break;
+                        }
                     }
                 }
             }
+
+            if (dual != AlgorithmType.NONE)
+            {
+                string coinP = "";
+                if (dual == AlgorithmType.Decred) {
+                    coinP = " -dcoin dcr ";
+                }
+                else if (dual == AlgorithmType.Lbry) {
+                    coinP = " -dcoin lbc ";
+                }
+                else if (dual == AlgorithmType.Pascal) {
+                    coinP = " -dcoin pasc ";
+                }
+                string urlSecond = Globals.GetLocationURL(dual, Globals.MiningLocation[ConfigManager.GeneralConfig.ServiceLocation], this.ConectionType);
+                dualModeParams = String.Format(" {0} -dpool {1} -dwal {2}", coinP, urlSecond, username);
+            }
+
             return " "
                 + GetDevicesCommandString()
                 + String.Format("  -epool {0} -ewal {1} -mport 127.0.0.1:{2} -esm 3 -epsw x -allpools 1", url, username, APIPort)

--- a/NiceHashMiner/Miners/Grouping/GroupSetupUtils.cs
+++ b/NiceHashMiner/Miners/Grouping/GroupSetupUtils.cs
@@ -121,10 +121,12 @@ namespace NiceHashMiner.Miners.Grouping {
                     if (minerDevIndex > -1) {
                         foreach (var avgKvp in calculatedAvaragers) {
                             string algo_id = avgKvp.Key;
-                            double avaragedSpeed = avgKvp.Value; 
+                            double avaragedSpeed = avgKvp.Value[0];
+                            double secondaryAveragedSpeed = avgKvp.Value[1];
                             int index = miningDevs[minerDevIndex].Algorithms.FindIndex((a) => a.AlgorithmStringID == algo_id);
                             if(index > -1) {
                                 miningDevs[minerDevIndex].Algorithms[index].AvaragedSpeed = avaragedSpeed;
+                                miningDevs[minerDevIndex].Algorithms[index].SecondaryAveragedSpeed = secondaryAveragedSpeed;
                             }
                         }
                     }
@@ -136,10 +138,17 @@ namespace NiceHashMiner.Miners.Grouping {
 
     class SpeedSumCount {
         public double speed = 0;
+        public double secondarySpeed = 0;
         public int count = 0;
         public double GetAvarage() {
             if (count > 0) {
                 return speed / (double)count;
+            }
+            return 0;
+        }
+        public double GetSecondaryAverage() {
+            if (count > 0) {
+                return secondarySpeed / (double)count;
             }
             return 0;
         }
@@ -150,12 +159,12 @@ namespace NiceHashMiner.Miners.Grouping {
         public List<string> UUIDsList = new List<string>();
         // algo_id, speed_sum, speed_count
         public Dictionary<string, SpeedSumCount> BenchmarkSums = new Dictionary<string, SpeedSumCount>();
-        public Dictionary<string, double> CalculateAvarages() {
-            Dictionary<string, double> ret = new Dictionary<string, double>();
+        public Dictionary<string, List<double>> CalculateAvarages() {
+            Dictionary<string, List<double>> ret = new Dictionary<string, List<double>>();
             foreach (var kvp in this.BenchmarkSums) {
                 string algo_id = kvp.Key;
                 SpeedSumCount ssc = kvp.Value;
-                ret[algo_id] = ssc.GetAvarage();
+                ret[algo_id] = new List<double> { ssc.GetAvarage(), ssc.GetSecondaryAverage() };
             }
             return ret;
         }
@@ -167,10 +176,12 @@ namespace NiceHashMiner.Miners.Grouping {
                     var ssc = new SpeedSumCount();
                     ssc.count = 1;
                     ssc.speed = algo.BenchmarkSpeed;
+                    ssc.secondarySpeed = algo.SecondaryBenchmarkSpeed;
                     BenchmarkSums[algo_id] = ssc;
                 } else {
                     BenchmarkSums[algo_id].count++;
                     BenchmarkSums[algo_id].speed += algo.BenchmarkSpeed;
+                    BenchmarkSums[algo_id].secondarySpeed += algo.SecondaryBenchmarkSpeed;
                 }
             }
         }

--- a/NiceHashMiner/Miners/Grouping/GroupingLogic.cs
+++ b/NiceHashMiner/Miners/Grouping/GroupingLogic.cs
@@ -24,7 +24,7 @@ namespace NiceHashMiner.Miners.Grouping {
             return a.Algorithm.MinerBinaryPath == b.Algorithm.MinerBinaryPath;
         }
         private static bool IsSameAlgorithmType(MiningPair a, MiningPair b) {
-            return a.Algorithm.NiceHashID == b.Algorithm.NiceHashID;
+            return a.Algorithm.DualNiceHashID() == b.Algorithm.DualNiceHashID();
         }
         private static bool IsSameDeviceType(MiningPair a, MiningPair b) {
             return a.Device.DeviceType == b.Device.DeviceType;

--- a/NiceHashMiner/Miners/Grouping/MiningDevice.cs
+++ b/NiceHashMiner/Miners/Grouping/MiningDevice.cs
@@ -74,11 +74,11 @@ namespace NiceHashMiner.Miners.Grouping {
         public MinerBaseType PrevProfitableMinerBaseType { get; private set; }
 
         private int GetMostProfitableIndex() {
-            return Algorithms.FindIndex((a) => a.NiceHashID == MostProfitableAlgorithmType && a.MinerBaseType == MostProfitableMinerBaseType);
+            return Algorithms.FindIndex((a) => a.DualNiceHashID() == MostProfitableAlgorithmType && a.MinerBaseType == MostProfitableMinerBaseType);
         }
 
         private int GetPrevProfitableIndex() {
-            return Algorithms.FindIndex((a) => a.NiceHashID == PrevProfitableAlgorithmType && a.MinerBaseType == PrevProfitableMinerBaseType);
+            return Algorithms.FindIndex((a) => a.DualNiceHashID() == PrevProfitableAlgorithmType && a.MinerBaseType == PrevProfitableMinerBaseType);
         }
 
         public double GetCurrentMostProfitValue {
@@ -129,12 +129,12 @@ namespace NiceHashMiner.Miners.Grouping {
                 if (NiceHashData.ContainsKey(key)) {
                     algo.CurNhmSMADataVal = NiceHashData[key].paying;
                     algo.CurrentProfit = algo.CurNhmSMADataVal * algo.AvaragedSpeed * 0.000000001;
+                    if (NiceHashData.ContainsKey(secondaryKey))  {
+                        algo.SecondaryCurNhmSMADataVal = NiceHashData[secondaryKey].paying;
+                        algo.CurrentProfit += algo.SecondaryCurNhmSMADataVal * algo.SecondaryAveragedSpeed * 0.000000001;
+                    }
                 } else {
                     algo.CurrentProfit = 0;
-                }
-                if (NiceHashData.ContainsKey(secondaryKey))
-                {
-                    algo.CurrentProfit += NiceHashData[secondaryKey].paying * algo.SecondaryAveragedSpeed * 0.000000001;
                 }
             }
             // find max paying value and save key
@@ -142,7 +142,7 @@ namespace NiceHashMiner.Miners.Grouping {
             foreach (var algo in Algorithms) {
                 if (maxProfit < algo.CurrentProfit) {
                     maxProfit = algo.CurrentProfit;
-                    MostProfitableAlgorithmType = algo.NiceHashID;
+                    MostProfitableAlgorithmType = algo.DualNiceHashID();
                     MostProfitableMinerBaseType = algo.MinerBaseType;
                 }
             }

--- a/NiceHashMiner/Miners/Grouping/MiningDevice.cs
+++ b/NiceHashMiner/Miners/Grouping/MiningDevice.cs
@@ -125,11 +125,16 @@ namespace NiceHashMiner.Miners.Grouping {
             // calculate new profits
             foreach (var algo in Algorithms) {
                 AlgorithmType key = algo.NiceHashID;
+                AlgorithmType secondaryKey = algo.SecondaryNiceHashID;
                 if (NiceHashData.ContainsKey(key)) {
                     algo.CurNhmSMADataVal = NiceHashData[key].paying;
                     algo.CurrentProfit = algo.CurNhmSMADataVal * algo.AvaragedSpeed * 0.000000001;
                 } else {
                     algo.CurrentProfit = 0;
+                }
+                if (NiceHashData.ContainsKey(secondaryKey))
+                {
+                    algo.CurrentProfit += NiceHashData[secondaryKey].paying * algo.SecondaryAveragedSpeed * 0.000000001;
                 }
             }
             // find max paying value and save key

--- a/NiceHashMiner/Miners/Grouping/MiningSetup.cs
+++ b/NiceHashMiner/Miners/Grouping/MiningSetup.cs
@@ -9,6 +9,7 @@ namespace NiceHashMiner.Miners.Grouping {
         public string MinerPath { get; private set; }
         public string MinerName { get; private set; }
         public AlgorithmType CurrentAlgorithmType { get; private set; }
+        public AlgorithmType CurrentSecondaryAlgorithmType { get; private set; }
         public bool IsInit { get; private set; }
 
         public MiningSetup(List<MiningPair> miningPairs) {
@@ -19,6 +20,7 @@ namespace NiceHashMiner.Miners.Grouping {
                 this.MiningPairs.Sort((a, b) => a.Device.ID - b.Device.ID);
                 this.MinerName = miningPairs[0].Algorithm.MinerName;
                 this.CurrentAlgorithmType = miningPairs[0].Algorithm.NiceHashID;
+                this.CurrentSecondaryAlgorithmType = miningPairs[0].Algorithm.SecondaryNiceHashID;
                 this.MinerPath = miningPairs[0].Algorithm.MinerBinaryPath;
                 this.IsInit = MinerPaths.IsValidMinerPath(this.MinerPath);
             }

--- a/NiceHashMiner/Miners/Miner.cs
+++ b/NiceHashMiner/Miners/Miner.cs
@@ -514,7 +514,7 @@ namespace NiceHashMiner
                 }
             }
             BenchmarkProcessStatus = status;
-            Helpers.ConsolePrint("BENCHMARK", "Final Speed: " + Helpers.FormatSpeedOutput(BenchmarkAlgorithm.BenchmarkSpeed));
+            Helpers.ConsolePrint("BENCHMARK", "Final Speed: " + Helpers.FormatDualSpeedOutput(BenchmarkAlgorithm.BenchmarkSpeed, BenchmarkAlgorithm.SecondaryBenchmarkSpeed));
             Helpers.ConsolePrint("BENCHMARK", "Benchmark ends");
             if (BenchmarkComunicator != null && !OnBenchmarkCompleteCalled) {
                 OnBenchmarkCompleteCalled = true;

--- a/NiceHashMiner/Miners/Miner.cs
+++ b/NiceHashMiner/Miners/Miner.cs
@@ -25,12 +25,29 @@ namespace NiceHashMiner
     public class APIData
     {
         public AlgorithmType AlgorithmID;
+        public AlgorithmType SecondaryAlgorithmID;
         public string AlgorithmName;
         public double Speed;
-        public APIData(AlgorithmType algorithmID) {
+        public double SecondarySpeed;
+        public APIData(AlgorithmType algorithmID, AlgorithmType secondaryAlgorithmID=AlgorithmType.NONE) {
             this.AlgorithmID = algorithmID;
-            this.AlgorithmName = AlgorithmNiceHashNames.GetName(algorithmID);
+            this.SecondaryAlgorithmID = secondaryAlgorithmID;
+            this.AlgorithmName = AlgorithmNiceHashNames.GetName(DualAlgorithmID());
             this.Speed = 0.0;
+            this.SecondarySpeed = 0.0;
+        }
+        public AlgorithmType DualAlgorithmID() {
+            if (AlgorithmID == AlgorithmType.DaggerHashimoto) {
+                switch (SecondaryAlgorithmID) {
+                    case AlgorithmType.Decred:
+                        return AlgorithmType.DaggerDecred;
+                    case AlgorithmType.Lbry:
+                        return AlgorithmType.DaggerLbry;
+                    case AlgorithmType.Pascal:
+                        return AlgorithmType.DaggerPascal;
+                }
+            }
+            return AlgorithmID;
         }
     }
 

--- a/NiceHashMiner/Miners/MinerFactory.cs
+++ b/NiceHashMiner/Miners/MinerFactory.cs
@@ -17,13 +17,13 @@ namespace NiceHashMiner.Miners {
             return null;
         }
 
-        private static Miner CreateClaymore(AlgorithmType algorithmType) {
+        private static Miner CreateClaymore(AlgorithmType algorithmType, AlgorithmType secondaryAlgorithmType) {
             if (AlgorithmType.Equihash == algorithmType) {
                 return new ClaymoreZcashMiner();
             } else if (AlgorithmType.CryptoNight == algorithmType) {
                 return new ClaymoreCryptoNightMiner();
             } else if (AlgorithmType.DaggerHashimoto == algorithmType) {
-                return new ClaymoreDual();
+                return new ClaymoreDual(secondaryAlgorithmType);
             }
             return null;
         }
@@ -35,7 +35,7 @@ namespace NiceHashMiner.Miners {
             return null;
         }
 
-        public static Miner CreateMiner(DeviceType deviceType, AlgorithmType algorithmType, MinerBaseType minerBaseType) {
+        public static Miner CreateMiner(DeviceType deviceType, AlgorithmType algorithmType, MinerBaseType minerBaseType, AlgorithmType secondaryAlgorithmType=AlgorithmType.NONE) {
             switch (minerBaseType) {
                 case MinerBaseType.ccminer:
                     return new ccminer();
@@ -46,7 +46,7 @@ namespace NiceHashMiner.Miners {
                 case MinerBaseType.ethminer:
                     return CreateEthminer(deviceType);
                 case MinerBaseType.ClaymoreAMD:
-                    return CreateClaymore(algorithmType);
+                    return CreateClaymore(algorithmType, secondaryAlgorithmType);
                 case MinerBaseType.OptiminerAMD:
                     return new OptiminerZcashMiner();
                 case MinerBaseType.excavator:
@@ -64,7 +64,7 @@ namespace NiceHashMiner.Miners {
         // create miner creates new miners based on device type and algorithm/miner path
         public static Miner CreateMiner(ComputeDevice device, Algorithm algorithm) {
             if (device != null && algorithm != null) {
-                return CreateMiner(device.DeviceType, algorithm.NiceHashID, algorithm.MinerBaseType);
+                return CreateMiner(device.DeviceType, algorithm.NiceHashID, algorithm.MinerBaseType, algorithm.SecondaryNiceHashID);
             }
             return null;
         }

--- a/NiceHashMiner/Miners/MiningSession.cs
+++ b/NiceHashMiner/Miners/MiningSession.cs
@@ -261,8 +261,8 @@ namespace NiceHashMiner.Miners {
                     foreach (var algo in device.Algorithms) {
                        stringBuilderDevice.AppendLine(String.Format("\t\tPROFIT = {0}\t(SPEED = {1}\t\t| NHSMA = {2})\t[{3}]",
                             algo.CurrentProfit.ToString(DOUBLE_FORMAT), // Profit
-                            algo.AvaragedSpeed, // Speed
-                            algo.CurNhmSMADataVal, // NiceHashData
+                            algo.AvaragedSpeed + (algo.IsDual() ? "/" + algo.SecondaryAveragedSpeed : ""), // Speed
+                            algo.CurNhmSMADataVal + (algo.IsDual() ? "/" + algo.SecondaryCurNhmSMADataVal : ""), // NiceHashData
                             algo.AlgorithmStringID // Name
                         ));
                     }

--- a/NiceHashMiner/Miners/MiningSession.cs
+++ b/NiceHashMiner/Miners/MiningSession.cs
@@ -259,7 +259,7 @@ namespace NiceHashMiner.Miners {
                     StringBuilder stringBuilderDevice = new StringBuilder();
                     stringBuilderDevice.AppendLine(String.Format("\tProfits for {0} ({1}):", device.Device.UUID, device.Device.GetFullName()));
                     foreach (var algo in device.Algorithms) {
-                        stringBuilderDevice.AppendLine(String.Format("\t\tPROFIT = {0}\t(SPEED = {1}\t\t| NHSMA = {2})\t[{3}]",
+                       stringBuilderDevice.AppendLine(String.Format("\t\tPROFIT = {0}\t(SPEED = {1}\t\t| NHSMA = {2})\t[{3}]",
                             algo.CurrentProfit.ToString(DOUBLE_FORMAT), // Profit
                             algo.AvaragedSpeed, // Speed
                             algo.CurNhmSMADataVal, // NiceHashData

--- a/NiceHashMiner/Miners/MiningSession.cs
+++ b/NiceHashMiner/Miners/MiningSession.cs
@@ -431,6 +431,9 @@ namespace NiceHashMiner.Miners {
                 // set rates
                 if (NiceHashData != null && AD != null) {
                     groupMiners.CurrentRate = NiceHashData[AD.AlgorithmID].paying * AD.Speed * 0.000000001;
+                    if (NiceHashData.ContainsKey(AD.SecondaryAlgorithmID)) {
+                        groupMiners.CurrentRate += NiceHashData[AD.SecondaryAlgorithmID].paying * AD.SecondarySpeed * 0.000000001;
+                    }
                 } else {
                     groupMiners.CurrentRate = 0;
                     // set empty

--- a/NiceHashMiner/Miners/ccminer.cs
+++ b/NiceHashMiner/Miners/ccminer.cs
@@ -163,7 +163,7 @@ namespace NiceHashMiner.Miners
 
                 var totalSpeed = 0.0d;
                 foreach (var miningPair in MiningSetup.MiningPairs) {
-                    var algo = miningPair.Device.GetAlgorithm(MinerBaseType.ccminer, AlgorithmType.CryptoNight);
+                    var algo = miningPair.Device.GetAlgorithm(MinerBaseType.ccminer, AlgorithmType.CryptoNight, AlgorithmType.NONE);
                     if (algo != null) {
                         totalSpeed += algo.BenchmarkSpeed;
                     }

--- a/NiceHashMiner/Utils/AlgorithmNiceHashNames.cs
+++ b/NiceHashMiner/Utils/AlgorithmNiceHashNames.cs
@@ -11,7 +11,7 @@ namespace NiceHashMiner
     public static class AlgorithmNiceHashNames
     {
         public static string GetName(AlgorithmType type) {
-            if (AlgorithmType.INVALID <= type && type <= AlgorithmType.X11Gost) {
+            if ((AlgorithmType.INVALID <= type && type <= AlgorithmType.X11Gost) || (AlgorithmType.DaggerDecred <= type && type <= AlgorithmType.DaggerPascal)) {
                 return Enum.GetName(typeof(AlgorithmType), type);
             }
             return "NameNotFound type not supported";

--- a/NiceHashMiner/Utils/Helpers.cs
+++ b/NiceHashMiner/Utils/Helpers.cs
@@ -124,19 +124,30 @@ namespace NiceHashMiner
             }
         }
 
-        public static string FormatSpeedOutput(double speed) {
+        public static string FormatSpeedOutput(double speed, string separator=" ") {
             string ret = "";
 
             if (speed < 1000)
-                ret = (speed).ToString("F3", CultureInfo.InvariantCulture) + " H/s ";
+                ret = (speed).ToString("F3", CultureInfo.InvariantCulture) + separator;
             else if (speed < 100000)
-                ret = (speed * 0.001).ToString("F3", CultureInfo.InvariantCulture) + " kH/s ";
+                ret = (speed * 0.001).ToString("F3", CultureInfo.InvariantCulture) + separator + "k";
             else if (speed < 100000000)
-                ret = (speed * 0.000001).ToString("F3", CultureInfo.InvariantCulture) + " MH/s ";
+                ret = (speed * 0.000001).ToString("F3", CultureInfo.InvariantCulture) + separator + "M";
             else
-                ret = (speed * 0.000000001).ToString("F3", CultureInfo.InvariantCulture) + " GH/s ";
+                ret = (speed * 0.000000001).ToString("F3", CultureInfo.InvariantCulture) + separator + "G";
 
             return ret;
+        }
+
+        public static string FormatDualSpeedOutput(double primarySpeed, double secondarySpeed=0) {
+            string ret;
+            if (secondarySpeed > 0) {
+                ret = FormatSpeedOutput(primarySpeed, "") + "/" + FormatSpeedOutput(secondarySpeed, "") + " ";
+            }
+            else {
+                ret = FormatSpeedOutput(primarySpeed);
+            }
+            return ret + "H/s ";
         }
 
         public static string GetMotherboardID() {

--- a/NiceHashMiner/langs/en.lang
+++ b/NiceHashMiner/langs/en.lang
@@ -157,6 +157,7 @@
 
         "Form_Settings_Algo_Skip": "Skip",
         "Form_Settings_Algo_BenchmarkSpeed": "Benchmark Speed (H/s)",
+        "Form_Settings_Algo_SecondaryBenchmarkSpeed":  "Secondary Benchmark Speed (H/s)",
 
         "Form_Settings_LessThreadWarningTitle": "Invalid number for LessThreads!",
         "Form_Settings_LessThreadWarningMsg": "Error! Please input a valid number for LessThreads.",
@@ -231,6 +232,7 @@
         "Form_Settings_ToolTip_AlgoSkip": "Check it if you would like to skip & disable a particular algorithm.\nBenchmarking as well as actual mining will be disabled for this particular algorithm.\nThat said, auto-switching will skip this algorithm when mining will be running.",
         "Form_Settings_ToolTip_AlgoUsePassword": "Use this password when launching miner and this algorithm. If not set, Groups's UsePassword is used.",
         "Form_Settings_ToolTip_AlgoBenchmarkSpeed": "Fine tune algorithm ratios by manually setting benchmark speeds for each algorithm.",
+        "Form_Settings_ToolTip_AlgoSecondaryBenchmarkSpeed": "Speed for the secondary algorithm when using dual algo mining.",
         "Form_Settings_ToolTip_AlgoDisabledDevices": "Any devices that are checked will be skipped by NiceHashMiner (only for this algorithm).",
         "Form_Settings_ToolTip_AlgoExtraLaunchParameters": "Additional launch parameters when launching miner and this algorithm.",
         "Form_Settings_Text_ContinueMiningIfNoInternetAccess" :  "Idle When No Internet Access",

--- a/NiceHashMiner/langs/es.lang
+++ b/NiceHashMiner/langs/es.lang
@@ -157,6 +157,7 @@
 
 		"Form_Settings_Algo_Skip": "Saltar",
 		"Form_Settings_Algo_BenchmarkSpeed": "Velocidad del benchmark (H/s)",
+    "Form_Settings_Algo_SecondaryBenchmarkSpeed": "Velocidad de referencia secundaria (H/s)",
 
 		"Form_Settings_LessThreadWarningTitle": "¡Número inválido para LessThreads!",
 		"Form_Settings_LessThreadWarningMsg": "¡Error! Por favor introduce un número valido para LessThreads.",
@@ -232,6 +233,7 @@
 		"Form_Settings_ToolTip_AlgoSkip": "Márcalo si quieres saltar y desactivar un algoritmo en particular.\nEl minado y el benchmark serán desactivados para este algoritmo en particular.\nEl cambio automático de algoritmo también ignorará este algoritmo.",
 		"Form_Settings_ToolTip_AlgoUsePassword": "Usa esta contraseña al iniciar este minero y este algoritmo. Si no se establece, UsePassword del grupo se usará.",
 		"Form_Settings_ToolTip_AlgoBenchmarkSpeed": "Personalización de los ratios de los algoritmos al cambiar manualmente las velocidades de los benchmark.",
+    "Form_Settings_ToolTip_AlgoSecondaryBenchmarkSpeed": "Velocidad para el algoritmo secundario cuando se utiliza minería de algo dual.",
 		"Form_Settings_ToolTip_AlgoDisabledDevices": "Todos los dispositivos marcados serán ignorados por NiceHash Miner (solo para este algoritmo).",
 		"Form_Settings_ToolTip_AlgoExtraLaunchParameters": "Parámetros de inicio adicionales al lanzar el minero y este algoritmo.",
 		"Form_Settings_DisplayCurrency": "Mostrar divisa",

--- a/NiceHashMiner/langs/ru.lang
+++ b/NiceHashMiner/langs/ru.lang
@@ -159,6 +159,7 @@
 
         "Form_Settings_Algo_Skip":"Пропустить",
         "Form_Settings_Algo_BenchmarkSpeed":"Скорость бенчмарка (H/s)",
+        "Form_Settings_Algo_SecondaryBenchmarkSpeed": "Средняя контрольная скорость",
 
         "Form_Settings_LessThreadWarningTitle":"Неверное значение LessThreads!",
         "Form_Settings_LessThreadWarningMsg":"Ошибка! Введите, пожалуйста, верное значение для LessThreads.",
@@ -233,6 +234,7 @@
         "Form_Settings_ToolTip_AlgoSkip":"Отметьте, если вы хотели бы пропустить/отключить определенный алгоритм. \nБенчмаркинг, а также фактический майнинг будут отключены для этого конкретного алгоритма. \nЭто означает, что автоматическое переключение будет пропускать этот алгоритм во время майнинга.",
         "Form_Settings_ToolTip_AlgoUsePassword":"Использовать этот пароль при запуске майнера и этого алгоритма. Если не указано, будет использоваться пароль группы.",
         "Form_Settings_ToolTip_AlgoBenchmarkSpeed":"Ручная настройка скорости бенчмарка для каждого алгоритма.",
+        "Form_Settings_ToolTip_AlgoSecondaryBenchmarkSpeed": "Скорость для вторичного алгоритма при использовании алгоритма двойного алгоритма.",
         "Form_Settings_ToolTip_AlgoDisabledDevices":"Отмеченные устройства будут пропущены NiceHashMiner (только для этого алгоритма).",
         "Form_Settings_ToolTip_AlgoExtraLaunchParameters":"Дополнительные параметры при запуске майнера и этого алгоритма.",
         "Form_Settings_DisplayCurrency": "Отображ. валюты",


### PR DESCRIPTION
This adds support for NHM to automatically switch the four different states of ClaymoreDual (just dagger plus dagger with three secondary coins) based on the profitability. The other three types of ClaymoreDual come up as their own miners (disabled by default) named as "DaggerDecred" etc. To keep UI modifications minimal I did not add any columns for secondary speed/profit, it is just displayed in the normal columns as [Daggerspeed]/[Secondaryspeed]. There is a new text box in the algo settings to change secondary speed though. 

The API will get the correct data and show it on the main screen, however the string gets too long and cut into by "Rate". I'm not sure if this is just my system because it is high-DPI, but I cannot edit anything using the designers as it completely fudges up the numbers for everything else.

For technical details, I added the ability for an Algorithm object to contain a secondary algo type and speed. In order to not mess too much with the profit switching logic I also added a method that returns a tandem algo index, which are defined in the AlgorithmType enum as -5,-4,-3. This allows the profit switching to see the miners as different since they have the same base type and main algorithm type (dagger). 

Benchmarking also works almost completely. Only problem is Claymore stops running if benchmark mode is off after around 2min if redirect output is true. It can't run in benchmark mode since only the ETH speeds are displayed.

I've been running this for around 2 weeks on my own personal rigs and there doesn't seem to be any problems. I do have multi card systems however I don't have any identical cards so I haven't tested that, but it should work fine as I updated the average logic to support the secondary speeds. It does really help to have it switch since Decred and Pascal are all over the place lately.