### PR TITLE
Ignore Videocontrollers that are not connected to hardware.

### DIFF
--- a/NiceHashMiner/Devices/ComputeDeviceManager.cs
+++ b/NiceHashMiner/Devices/ComputeDeviceManager.cs
@@ -268,7 +268,7 @@ namespace NiceHashMiner.Devices
                     StringBuilder stringBuilder = new StringBuilder();
                     stringBuilder.AppendLine("");
                     stringBuilder.AppendLine("QueryVideoControllers: ");
-                    ManagementObjectCollection moc = new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_VideoController").Get();
+                    ManagementObjectCollection moc = new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_VideoController LIKE 'PCI%'").Get();
                     bool allVideoContollersOK = true;
                     foreach (var manObj in moc) {
                         ulong memTmp = 0;

--- a/NiceHashMiner/Devices/ComputeDeviceManager.cs
+++ b/NiceHashMiner/Devices/ComputeDeviceManager.cs
@@ -268,7 +268,7 @@ namespace NiceHashMiner.Devices
                     StringBuilder stringBuilder = new StringBuilder();
                     stringBuilder.AppendLine("");
                     stringBuilder.AppendLine("QueryVideoControllers: ");
-                    ManagementObjectCollection moc = new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_VideoController LIKE 'PCI%'").Get();
+                    ManagementObjectCollection moc = new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_VideoController WHERE PNPDeviceID LIKE 'PCI\\%'").Get();
                     bool allVideoContollersOK = true;
                     foreach (var manObj in moc) {
                         ulong memTmp = 0;


### PR DESCRIPTION
As some remote administration software install Mirror drivers that trigger video controller warnings. I propose a change to make NiceHashMiner only detect video controllers connected to the PCI bus.