### PR TITLE
remove warnings & catch exception on query Win32_VideoController data

### DIFF
--- a/NiceHashMiner/Devices/ComputeDeviceManager.cs
+++ b/NiceHashMiner/Devices/ComputeDeviceManager.cs
@@ -268,36 +268,46 @@ namespace NiceHashMiner.Devices
                     StringBuilder stringBuilder = new StringBuilder();
                     stringBuilder.AppendLine("");
                     stringBuilder.AppendLine("QueryVideoControllers: ");
-                    ManagementObjectCollection moc = new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_VideoController WHERE PNPDeviceID LIKE 'PCI\\%'").Get();
                     bool allVideoContollersOK = true;
-                    foreach (var manObj in moc) {
-                        ulong memTmp = 0;
-                        //Int16 ram_Str = manObj["ProtocolSupported"] as Int16; manObj["AdapterRAM"] as string
-                        UInt64.TryParse(SafeGetProperty(manObj, "AdapterRAM"), out memTmp);
-                        var vidController = new VideoControllerData() {
-                            Name = SafeGetProperty(manObj, "Name"),
-                            Description = SafeGetProperty(manObj, "Description"),
-                            PNPDeviceID = SafeGetProperty(manObj, "PNPDeviceID"),
-                            DriverVersion = SafeGetProperty(manObj, "DriverVersion"),
-                            Status = SafeGetProperty(manObj, "Status"),
-                            InfSection = SafeGetProperty(manObj, "InfSection"),
-                            AdapterRAM = memTmp
-                        };
-                        stringBuilder.AppendLine("\tWin32_VideoController detected:");
-                        stringBuilder.AppendLine(String.Format("\t\tName {0}", vidController.Name));
-                        stringBuilder.AppendLine(String.Format("\t\tDescription {0}", vidController.Description));
-                        stringBuilder.AppendLine(String.Format("\t\tPNPDeviceID {0}", vidController.PNPDeviceID));
-                        stringBuilder.AppendLine(String.Format("\t\tDriverVersion {0}", vidController.DriverVersion));
-                        stringBuilder.AppendLine(String.Format("\t\tStatus {0}", vidController.Status));
-                        stringBuilder.AppendLine(String.Format("\t\tInfSection {0}", vidController.InfSection));
-                        stringBuilder.AppendLine(String.Format("\t\tAdapterRAM {0}", vidController.AdapterRAM));
+                    using (var moc = new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_VideoController WHERE PNPDeviceID LIKE 'PCI\\%'").Get())
+                    {
+                        try
+                        {
+                            foreach (var manObj in moc)
+                            {
+                                ulong memTmp = 0;
+                                //Int16 ram_Str = manObj["ProtocolSupported"] as Int16; manObj["AdapterRAM"] as string
+                                UInt64.TryParse(SafeGetProperty(manObj, "AdapterRAM"), out memTmp);
+                                var vidController = new VideoControllerData()
+                                {
+                                    Name = SafeGetProperty(manObj, "Name"),
+                                    Description = SafeGetProperty(manObj, "Description"),
+                                    PNPDeviceID = SafeGetProperty(manObj, "PNPDeviceID"),
+                                    DriverVersion = SafeGetProperty(manObj, "DriverVersion"),
+                                    Status = SafeGetProperty(manObj, "Status"),
+                                    InfSection = SafeGetProperty(manObj, "InfSection"),
+                                    AdapterRAM = memTmp
+                                };
+                                stringBuilder.AppendLine("\tWin32_VideoController detected:");
+                                stringBuilder.AppendLine(String.Format("\t\tName {0}", vidController.Name));
+                                stringBuilder.AppendLine(String.Format("\t\tDescription {0}", vidController.Description));
+                                stringBuilder.AppendLine(String.Format("\t\tPNPDeviceID {0}", vidController.PNPDeviceID));
+                                stringBuilder.AppendLine(String.Format("\t\tDriverVersion {0}", vidController.DriverVersion));
+                                stringBuilder.AppendLine(String.Format("\t\tStatus {0}", vidController.Status));
+                                stringBuilder.AppendLine(String.Format("\t\tInfSection {0}", vidController.InfSection));
+                                stringBuilder.AppendLine(String.Format("\t\tAdapterRAM {0}", vidController.AdapterRAM));
 
-                        // check if controller ok
-                        if (allVideoContollersOK && !vidController.Status.ToLower().Equals("ok")) {
-                            allVideoContollersOK = false;
+                                // check if controller ok
+                                if (allVideoContollersOK && !vidController.Status.ToLower().Equals("ok"))
+                                    allVideoContollersOK = false;
+
+                                AvaliableVideoControllers.Add(vidController);
+                            }
                         }
-
-                        AvaliableVideoControllers.Add(vidController);
+                        catch (Exception e)
+                        {
+                            Helpers.ConsolePrint(TAG, "QueryVideoControllers threw exception: " + e.Message);
+                        }
                     }
                     Helpers.ConsolePrint(TAG, stringBuilder.ToString());
                     if (ConfigManager.GeneralConfig.ShowDriverVersionWarning && !allVideoContollersOK) {

--- a/NiceHashMiner/Forms/Form_Main.cs
+++ b/NiceHashMiner/Forms/Form_Main.cs
@@ -834,12 +834,10 @@ namespace NiceHashMiner
 
             // Check if there are unbenchmakred algorithms
             bool isBenchInit = true;
-            bool hasAnyAlgoEnabled = false;
             foreach (var cdev in ComputeDeviceManager.Avaliable.AllAvaliableDevices) {
                 if (cdev.Enabled) {
                     foreach (var algo in cdev.GetAlgorithmSettings()) {
                         if (algo.Enabled == true) {
-                            hasAnyAlgoEnabled = true;
                             if (algo.BenchmarkSpeed == 0) {
                                 isBenchInit = false;
                                 break;

--- a/NiceHashMiner/Miners/Equihash/OptiminerZcashMiner.cs
+++ b/NiceHashMiner/Miners/Equihash/OptiminerZcashMiner.cs
@@ -29,11 +29,11 @@ namespace NiceHashMiner.Miners.Equihash {
         }
 
         private class JsonApiResponse {
-            public double uptime;
-            public Dictionary<string, Dictionary<string, double>> solution_rate;
-            public Dictionary<string, double> share;
-            public Dictionary<string, Dictionary<string, double>> iteration_rate;
-            public Stratum stratum;
+            public double uptime { get; set; }
+            public Dictionary<string, Dictionary<string, double>> solution_rate { get; set; }
+            public Dictionary<string, double> share { get; set; }
+            public Dictionary<string, Dictionary<string, double>> iteration_rate { get; set; }
+            public Stratum stratum { get; set; }
         }
 
         // give some time or else it will crash

--- a/NiceHashMiner/Miners/Grouping/GroupSetupUtils.cs
+++ b/NiceHashMiner/Miners/Grouping/GroupSetupUtils.cs
@@ -155,7 +155,6 @@ namespace NiceHashMiner.Miners.Grouping {
     }
 
     class AvaragerGroup {
-        public string DeviceName;
         public List<string> UUIDsList = new List<string>();
         // algo_id, speed_sum, speed_count
         public Dictionary<string, SpeedSumCount> BenchmarkSums = new Dictionary<string, SpeedSumCount>();

--- a/NiceHashMiner/Utils/Logger.cs
+++ b/NiceHashMiner/Utils/Logger.cs
@@ -39,7 +39,7 @@ namespace NiceHashMiner
 
                 h.Root.AddAppender(CreateFileAppender());
                 h.Configured = true;
-            } catch (Exception e) {
+            } catch (Exception) {
                 IsInit = false;
             }
         }


### PR DESCRIPTION
I have problem with start NiceHash.

var moc = new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_VideoController WHERE PNPDeviceID LIKE 'PCI\\%'").Get();
foreach (var manObj in moc) 
{ ... }

foreach throw exception "invalid request".

Fix it

potentially fixed: https://github.com/nicehash/NiceHashMiner/issues/1047